### PR TITLE
fix(critical): ajouter FavorisProvider manquant (crash production sur toute page produit)

### DIFF
--- a/T-Express-Frontend/src/app/(site)/layout.tsx
+++ b/T-Express-Frontend/src/app/(site)/layout.tsx
@@ -13,6 +13,7 @@ import PreviewSliderModal from "@/components/Common/PreviewSlider";
 import ScrollToTop from "@/components/Common/ScrollToTop";
 import { AuthProvider } from "@/context/AuthContext";
 import { PanierProvider } from "@/context/PanierContext";
+import { FavorisProvider } from "@/context/FavorisContext";
 import { HeroProvider } from "@/context/HeroContext";
 
 export default function RootLayout({
@@ -25,22 +26,24 @@ export default function RootLayout({
       <ReduxProvider>
         <AuthProvider>
           <PanierProvider>
-            <HeroProvider>
-              <CartModalProvider>
-                <ModalProvider>
-                  <PreviewSliderProvider>
-                    <Header />
-                    {/* Ajout du ToastProvider pour les notifications */}
-                    {require("@/components/Common/ToastProvider").default()}
-                    {children}
+            <FavorisProvider>
+              <HeroProvider>
+                <CartModalProvider>
+                  <ModalProvider>
+                    <PreviewSliderProvider>
+                      <Header />
+                      {/* Ajout du ToastProvider pour les notifications */}
+                      {require("@/components/Common/ToastProvider").default()}
+                      {children}
 
-                  <QuickViewModal />
-                  <CartSidebarModal />
-                  <PreviewSliderModal />
-                </PreviewSliderProvider>
-              </ModalProvider>
-            </CartModalProvider>
-            </HeroProvider>
+                    <QuickViewModal />
+                    <CartSidebarModal />
+                    <PreviewSliderModal />
+                  </PreviewSliderProvider>
+                </ModalProvider>
+              </CartModalProvider>
+              </HeroProvider>
+            </FavorisProvider>
           </PanierProvider>
         </AuthProvider>
       </ReduxProvider>


### PR DESCRIPTION
## Incident
Chaque clic sur un produit faisait planter le site en production (t-express.shop) avec "Application error: a client-side exception has occurred". Reproduit et confirme avec Playwright :
```
[pageerror] useFavorisContext must be used within a FavorisProvider
```

## Cause
`FavorisProvider` (`src/context/FavorisContext.tsx`) n'etait jamais monte dans `src/app/(site)/layout.tsx`. Tout appel a `useFavorisContext()` (dont `ShopDetailsNew.tsx`) levait une exception non rattrapee des le rendu.

## Correction
Ajout de `<FavorisProvider>` dans l'arbre de providers du layout racine, a cote de `<PanierProvider>`.

Closes #42