### PR TITLE
fix(critical): ne plus rediriger de force vers /login sur un 401

### DIFF
--- a/T-Express-Frontend/src/lib/api-client.ts
+++ b/T-Express-Frontend/src/lib/api-client.ts
@@ -141,12 +141,14 @@ class ApiClient {
         // Si la réponse n'est pas du JSON
       }
 
-      // Si 401, déconnecter l'utilisateur (sauf pour les pages super-admin)
+      // Si 401, invalider le token local. On ne redirige PAS automatiquement :
+      // beaucoup d'appels (favoris, panier...) sont faits en arrière-plan
+      // pour un visiteur non connecté, sur des pages publiques (fiche
+      // produit, boutique...) ; les rediriger de force vers /login cassait
+      // la navigation anonyme. Les pages qui exigent une connexion gèrent
+      // déjà leur propre redirection via authService.isAuthenticated().
       if (response.status === 401) {
         this.clearAuthToken();
-        if (typeof window !== 'undefined' && !window.location.pathname.includes('super-admin')) {
-          window.location.href = '/login';
-        }
       }
 
       throw errorData;


### PR DESCRIPTION
## Incident
Suite au fix de #42, verification en direct : une fiche produit visitee sans etre connecte redirige immediatement vers /signin. Les visiteurs anonymes ne peuvent plus du tout consulter le catalogue.

## Cause
`apiClient.handleResponse()` forcait `window.location.href = '/login'` sur toute reponse 401, y compris pour des appels optionnels d'arriere-plan (favoris) faits sur des pages publiques.

## Correction
Le token local est toujours invalide sur 401, mais on ne redirige plus de force la page. Les pages protegees gerent deja leur propre garde d'authentification.

Closes #44