### PR TITLE
fix: remplacer les titres de page 'NextCommerce' par du contenu T-Express

### DIFF
--- a/T-Express-Frontend/src/app/(site)/(pages)/cart/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/cart/page.tsx
@@ -3,8 +3,8 @@ import Cart from "@/components/Cart";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Cart Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Cart Page for NextCommerce Template",
+  title: "Mon panier | T-Express",
+  description: "Consultez et modifiez le contenu de votre panier T-Express avant de passer commande.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/(pages)/contact/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/contact/page.tsx
@@ -2,8 +2,8 @@ import Contact from "@/components/Contact";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Contact Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Contact Page for NextCommerce Template",
+  title: "Contact | T-Express",
+  description: "Contactez l'équipe T-Express pour toute question sur vos commandes ou nos produits.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/(pages)/error/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/error/page.tsx
@@ -3,8 +3,8 @@ import Error from "@/components/Error";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Error Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Error Page for NextCommerce Template",
+  title: "Page introuvable | T-Express",
+  description: "La page que vous recherchez est introuvable sur T-Express.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/(pages)/mail-success/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/mail-success/page.tsx
@@ -3,8 +3,8 @@ import MailSuccess from "@/components/MailSuccess";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Mail Success Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Mail Success Page for NextCommerce Template",
+  title: "Message envoyé | T-Express",
+  description: "Votre message a bien été envoyé à l'équipe T-Express.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/(pages)/shop-with-sidebar/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/shop-with-sidebar/page.tsx
@@ -3,8 +3,8 @@ import ShopWithSidebar from "@/components/ShopWithSidebar";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Shop Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Shop Page for NextCommerce Template",
+  title: "Boutique | T-Express",
+  description: "Parcourez tous les produits disponibles sur T-Express, filtrez par catégorie et trouvez ce qu'il vous faut.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/(pages)/shop-without-sidebar/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/shop-without-sidebar/page.tsx
@@ -3,8 +3,8 @@ import ShopWithoutSidebar from "@/components/ShopWithoutSidebar";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Shop Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Shop Page for NextCommerce Template",
+  title: "Boutique | T-Express",
+  description: "Parcourez tous les produits disponibles sur T-Express.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/(pages)/signin/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/signin/page.tsx
@@ -2,8 +2,8 @@ import Signin from "@/components/Auth/Signin";
 import React from "react";
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Signin Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Signin Page for NextCommerce Template",
+  title: "Connexion | T-Express",
+  description: "Connectez-vous à votre compte T-Express pour suivre vos commandes et vos favoris.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/(pages)/signup/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/signup/page.tsx
@@ -3,8 +3,8 @@ import React from "react";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Signup Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Signup Page for NextCommerce Template",
+  title: "Créer un compte | T-Express",
+  description: "Créez votre compte T-Express pour commander et suivre vos livraisons.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/blogs/blog-details-with-sidebar/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/blogs/blog-details-with-sidebar/page.tsx
@@ -3,8 +3,8 @@ import BlogDetailsWithSidebar from "@/components/BlogDetailsWithSidebar";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Blog Details Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Blog Details Page for NextCommerce Template",
+  title: "Article | T-Express",
+  description: "Découvrez cet article du blog T-Express.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/blogs/blog-details/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/blogs/blog-details/page.tsx
@@ -3,8 +3,8 @@ import React from "react";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Blog Details Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Blog Details Page for NextCommerce Template",
+  title: "Article | T-Express",
+  description: "Découvrez cet article du blog T-Express.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/blogs/blog-grid-with-sidebar/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/blogs/blog-grid-with-sidebar/page.tsx
@@ -3,8 +3,8 @@ import BlogGridWithSidebar from "@/components/BlogGridWithSidebar";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Blog Grid Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Blog Grid Page for NextCommerce Template",
+  title: "Blog | T-Express",
+  description: "Actualités, conseils et nouveautés T-Express.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/blogs/blog-grid/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/blogs/blog-grid/page.tsx
@@ -3,8 +3,8 @@ import BlogGrid from "@/components/BlogGrid";
 
 import { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "Blog Grid Page | NextCommerce Nextjs E-commerce template",
-  description: "This is Blog Grid Page for NextCommerce Template",
+  title: "Blog | T-Express",
+  description: "Actualités, conseils et nouveautés T-Express.",
   // other metadata
 };
 

--- a/T-Express-Frontend/src/app/(site)/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/page.tsx
@@ -2,8 +2,8 @@ import Home from "@/components/Home";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "NextCommerce | Nextjs E-commerce template",
-  description: "This is Home for NextCommerce Template",
+  title: "T-Express | Votre boutique en ligne au Sénégal",
+  description: "T-Express, la plateforme e-commerce sénégalaise : produits de qualité, paiement adapté et livraison partout au Sénégal.",
   // other metadata
 };
 


### PR DESCRIPTION
## Probleme
13 pages (dont la page d'accueil) affichaient encore les metadata `title`/`description` du template d'origine "NextCommerce Nextjs E-commerce template" au lieu de contenu T-Express.

## Correction
Titres et descriptions remplaces en francais, coherents avec chaque page, sur le meme modele que les pages deja correctes (shop-details, wishlist, checkout, my-account).

Closes #9