### PR TITLE
fix: traduire en francais les composants MailSuccess et Error

### DIFF
--- a/T-Express-Frontend/src/components/Error/index.tsx
+++ b/T-Express-Frontend/src/components/Error/index.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 const Error = () => {
   return (
     <>
-      <Breadcrumb title={"Error"} pages={["error"]} />
+      <Breadcrumb title={"Page introuvable"} pages={["erreur"]} />
       <section className="overflow-hidden py-20 bg-gray-2">
         <div className="max-w-[1170px] w-full mx-auto px-4 sm:px-8 xl:px-0">
           <div className="bg-white rounded-xl shadow-1 px-4 py-10 sm:py-15 lg:py-20 xl:py-25">
@@ -20,12 +20,12 @@ const Error = () => {
               />
 
               <h2 className="font-medium text-dark text-xl sm:text-2xl mb-3">
-                Sorry, the page can’t be found
+                Désolé, cette page est introuvable
               </h2>
 
               <p className="max-w-[410px] w-full mx-auto mb-7.5">
-                The page you were looking for appears to have been moved,
-                deleted or does not exist.
+                La page que vous recherchez semble avoir été déplacée,
+                supprimée ou n'existe pas.
               </p>
 
               <Link
@@ -45,7 +45,7 @@ const Error = () => {
                     fill=""
                   />
                 </svg>
-                Back to Home
+                Retour à l'accueil
               </Link>
             </div>
           </div>

--- a/T-Express-Frontend/src/components/MailSuccess/index.tsx
+++ b/T-Express-Frontend/src/components/MailSuccess/index.tsx
@@ -5,22 +5,23 @@ import Link from "next/link";
 const MailSuccess = () => {
   return (
     <>
-      <Breadcrumb title={"MailSuccess"} pages={["MailSuccess"]} />
+      <Breadcrumb title={"Message envoyé"} pages={["Message envoyé"]} />
       <section className="overflow-hidden py-20 bg-gray-2">
         <div className="max-w-[1170px] w-full mx-auto px-4 sm:px-8 xl:px-0">
           <div className="bg-white rounded-xl shadow-1 px-4 py-10 sm:py-15 lg:py-20 xl:py-25">
             <div className="text-center">
               <h2 className="font-bold text-blue text-4xl lg:text-[45px] lg:leading-[57px] mb-5">
-                Successful!
+                Message envoyé !
               </h2>
 
               <h3 className="font-medium text-dark text-xl sm:text-2xl mb-3">
-                Your message sent successfully
+                Votre message a bien été envoyé
               </h3>
 
               <p className="max-w-[491px] w-full mx-auto mb-7.5">
-                Thank you so much for your message. We check e-mail frequently
-                and will try our best to respond to your inquiry.
+                Merci pour votre message. Nous consultons nos emails
+                régulièrement et ferons de notre mieux pour vous répondre
+                rapidement.
               </p>
 
               <Link
@@ -40,7 +41,7 @@ const MailSuccess = () => {
                     fill=""
                   />
                 </svg>
-                Back to Home
+                Retour à l'accueil
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Probleme
`src/components/MailSuccess/index.tsx` et `src/components/Error/index.tsx` etaient restes en anglais ("Successful!", "Sorry, the page can't be found"...) alors que le reste du site est en francais.

## Correction
Traduction complete des deux composants (titres, textes, bouton, breadcrumb).

Closes #13