### PR TITLE
fix: uniformiser l'etat d'erreur/retry sur les pages admin

### DIFF
--- a/T-Express-Frontend/src/app/admin/commandes/page.tsx
+++ b/T-Express-Frontend/src/app/admin/commandes/page.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { commandeService } from "@/services/commande.service";
 import type { Commande, CommandeStatut } from "@/types/api.types";
 import { LOCALE_CONFIG } from "@/config/api.config";
+import AdminErrorState from "@/components/Admin/AdminErrorState";
 
 // Statuts de commande (affichage seulement, pas modifiable directement)
 const STATUTS_COMMANDE: Record<string, { label: string; color: string }> = {
@@ -116,7 +117,7 @@ export default function AdminCommandes() {
         {loading && !commandes.length ? (
           <div className="text-center py-8">Chargement...</div>
         ) : error ? (
-          <div className="text-red-600 mb-4">{error}</div>
+          <AdminErrorState message={error} onRetry={fetchCommandes} />
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-left text-sm">

--- a/T-Express-Frontend/src/app/admin/produits/page.tsx
+++ b/T-Express-Frontend/src/app/admin/produits/page.tsx
@@ -6,6 +6,7 @@ import type { Produit, Categorie, AdminProduitData } from "@/types/api.types";
 import { LOCALE_CONFIG } from "@/config/api.config";
 import { resolveBackendImageUrl } from "@/lib/image";
 import toast from "react-hot-toast";
+import AdminErrorState from "@/components/Admin/AdminErrorState";
 
 export default function AdminProduits() {
   const [produits, setProduits] = useState<Produit[]>([]);
@@ -272,25 +273,7 @@ export default function AdminProduits() {
             </div>
           </div>
         ) : error ? (
-          <div className="bg-red-light-6 border-2 border-red-light-3 rounded-xl p-6 m-6">
-            <div className="flex items-start gap-4">
-              <div className="bg-red p-3 rounded-xl text-white">
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <h3 className="text-lg font-bold text-red-dark mb-2">Erreur de connexion</h3>
-                <p className="text-red-dark mb-4">{error}</p>
-                <button
-                  onClick={fetchData}
-                  className="bg-red text-white px-4 py-2 rounded-lg font-medium hover:bg-red-dark transition-colors"
-                >
-                  Réessayer
-                </button>
-              </div>
-            </div>
-          </div>
+          <AdminErrorState message={error} onRetry={fetchData} />
         ) : (
           <>
             <div className="overflow-x-auto">

--- a/T-Express-Frontend/src/app/admin/stocks/page.tsx
+++ b/T-Express-Frontend/src/app/admin/stocks/page.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { stockService } from "@/services/stock.service";
 import { produitService } from "@/services/produit.service";
 import type { Stock, Produit } from "@/types/api.types";
+import AdminErrorState from "@/components/Admin/AdminErrorState";
 
 export default function AdminStocks() {
   const [stocks, setStocks] = useState<Stock[]>([]);
@@ -81,7 +82,7 @@ export default function AdminStocks() {
         {loading ? (
           <div>Chargement...</div>
         ) : error ? (
-          <div className="text-red-600 mb-4">{error}</div>
+          <AdminErrorState message={error} onRetry={fetchData} />
         ) : (
           <table className="w-full text-left">
             <thead>

--- a/T-Express-Frontend/src/components/Admin/AdminErrorState.tsx
+++ b/T-Express-Frontend/src/components/Admin/AdminErrorState.tsx
@@ -1,0 +1,40 @@
+"use client";
+import React from "react";
+
+interface AdminErrorStateProps {
+  message: string;
+  onRetry: () => void;
+  title?: string;
+}
+
+/**
+ * Etat d'erreur standard pour les pages admin (liste + bouton Réessayer),
+ * repris du pattern déjà utilisé sur produits/categories/livraisons.
+ */
+export default function AdminErrorState({
+  message,
+  onRetry,
+  title = "Erreur de connexion",
+}: AdminErrorStateProps) {
+  return (
+    <div className="bg-red-light-6 border-2 border-red-light-3 rounded-xl p-6 m-6">
+      <div className="flex items-start gap-4">
+        <div className="bg-red p-3 rounded-xl text-white">
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-lg font-bold text-red-dark mb-2">{title}</h3>
+          <p className="text-red-dark mb-4">{message}</p>
+          <button
+            onClick={onRetry}
+            className="bg-red text-white px-4 py-2 rounded-lg font-medium hover:bg-red-dark transition-colors"
+          >
+            Réessayer
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Probleme
Les pages admin `stocks` et `commandes` affichaient une erreur de chargement en texte simple sans bouton "Reessayer", contrairement a `produits` (et `categories`/`livraisons`) qui ont deja une carte d'erreur stylisee avec retry.

## Correction
Extraction du pattern deja utilise sur `produits` dans un composant partage `src/components/Admin/AdminErrorState.tsx`, applique sur `stocks`, `commandes` et `produits` (qui utilise maintenant le composant partage au lieu de dupliquer le markup).

Closes #25