### PR TITLE
fix: afficher le nom du client dans le tableau des livraisons admin

### DIFF
--- a/T-Express-Frontend/src/app/admin/livraisons/page.tsx
+++ b/T-Express-Frontend/src/app/admin/livraisons/page.tsx
@@ -153,8 +153,9 @@ export default function AdminLivraisons() {
                             {`#${l.commande_id}`}
                           </td>
                           <td className="px-6 py-4 text-dark">
-                            {/* Client info not available from Livraison, display placeholder */}
-                            -
+                            {l.commande?.client
+                              ? `${l.commande.client.prenom} ${l.commande.client.nom}`
+                              : "-"}
                           </td>
                           <td className="px-6 py-4 text-dark-4">
                             {l.numero_suivi || "-"}

--- a/T-Express-Frontend/src/types/api.types.ts
+++ b/T-Express-Frontend/src/types/api.types.ts
@@ -319,6 +319,16 @@ export interface Livraison {
   notes?: string;
   created_at: string;
   updated_at: string;
+  // Chargée par le backend via Livraison::with(['commande.client', 'adresse'])
+  commande?: {
+    id: number;
+    client?: {
+      id: number;
+      nom: string;
+      prenom: string;
+      email?: string;
+    };
+  };
 }
 
 // ========== Avis ==========


### PR DESCRIPTION
## Probleme
La colonne "Client" du tableau des livraisons admin affichait toujours "-", avec un commentaire "Client info not available from Livraison". Or le backend (`AdminLivraisonController::liste`) charge deja `Livraison::with(['commande.client', 'adresse'])` et renvoie donc bien `commande.client` dans la reponse -- le frontend l'ignorait simplement (le type TypeScript `Livraison` ne declarait meme pas ce champ).

## Correction
- Ajout du champ `commande.client` au type `Livraison`
- Affichage du nom du client dans le tableau

Closes #33