### PR TITLE
fix(security): retirer les logs de debogage exposant des donnees sensibles

### DIFF
--- a/T-Express-Frontend/src/components/Checkout/CheckoutNew.tsx
+++ b/T-Express-Frontend/src/components/Checkout/CheckoutNew.tsx
@@ -85,57 +85,41 @@ const CheckoutNew = () => {
   // Soumettre la commande
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-    console.log("🚀 handleSubmit appelé");
-    console.log("📦 Mode de paiement:", paymentMethod);
-    console.log("👤 User:", user);
-    console.log("🛒 Panier:", panier);
 
     if (!user) {
-      console.log("❌ Pas d'utilisateur connecté");
       alert("Vous devez être connecté pour passer commande");
       router.push("/signin");
       return;
     }
 
     if (!selectedAdresseId && !showNewAddress) {
-      console.log("❌ Pas d'adresse sélectionnée");
       alert("Veuillez sélectionner une adresse de livraison");
       return;
     }
 
     if (!panier || panier.lignes.length === 0) {
-      console.log("❌ Panier vide");
       alert("Votre panier est vide");
       return;
     }
 
     try {
       setProcessing(true);
-      console.log("⏳ Traitement en cours...");
 
       // Créer une nouvelle adresse si nécessaire
       let adresseId = selectedAdresseId;
       if (showNewAddress && newAddress.adresse_ligne_1) {
-        console.log("📍 Création d'une nouvelle adresse...");
-        console.log("📋 Données adresse:", newAddress);
-        
         // Valider le téléphone si fourni
         if (newAddress.telephone && !validatePhone(newAddress.telephone)) {
-          console.log("❌ Téléphone invalide:", newAddress.telephone);
           toast.error("Le numéro de téléphone n'est pas valide. Format attendu : +221 XX XXX XX XX");
           setProcessing(false);
           return;
         }
-        
+
         try {
           const nouvelleAdresse = await adresseService.ajouter(newAddress);
           adresseId = nouvelleAdresse.id;
-          console.log("✅ Adresse créée avec ID:", adresseId);
         } catch (adresseError: any) {
-          console.error("❌ ERREUR création adresse:", adresseError);
-          console.error("❌ Message:", adresseError.message);
-          console.error("❌ Response:", adresseError.response);
+          console.error("Erreur création adresse:", adresseError.message);
           toast.error("Erreur lors de la création de l'adresse: " + (adresseError.message || "Erreur inconnue"));
           setProcessing(false);
           return;
@@ -143,7 +127,6 @@ const CheckoutNew = () => {
       }
 
       if (!adresseId) {
-        console.log("❌ Pas d'adresse ID");
         alert("Veuillez fournir une adresse de livraison");
         setProcessing(false);
         return;
@@ -158,17 +141,10 @@ const CheckoutNew = () => {
         frais_livraison: shippingMethod === "express" ? 5000 : 2000
       };
 
-      console.log("📝 Données commande:", commandeData);
-      console.log("🔄 Appel API création commande...");
-      
       const commande = await commandeService.creer(commandeData);
-      
-      console.log("✅ Commande créée:", commande);
-      console.log("💰 Mode de paiement:", paymentMethod);
-      
+
       // Si paiement en espèces, rediriger vers mes commandes
       if (paymentMethod === "especes") {
-        console.log("💵 Paiement en espèces - Redirection vers mes commandes");
         toast.success(`Commande ${commande.numero_commande} créée avec succès ! Paiement à la livraison.`);
         router.push(`/my-account/orders`);
         return;
@@ -178,19 +154,15 @@ const CheckoutNew = () => {
       // Inclure le téléphone pour éviter de le redemander
       const telephone = newAddress.telephone || user.telephone || '';
       const paymentUrl = `/payment?commande_id=${commande.id}&mode=${paymentMethod}&montant=${totalWithShipping}&telephone=${encodeURIComponent(telephone)}`;
-      console.log("💳 Paiement électronique - Redirection vers:", paymentUrl);
-      console.log("📞 Téléphone transmis:", telephone);
       toast.success(`Commande ${commande.numero_commande} créée ! Redirection vers le paiement...`);
-      
+
       // Utiliser window.location pour forcer la navigation
       window.location.href = paymentUrl;
     } catch (error: any) {
-      console.error("❌ Erreur lors de la création de la commande:", error);
-      console.error("❌ Détails:", error.response || error.message);
+      console.error("Erreur lors de la création de la commande:", error.message);
       toast.error(error.message || "Erreur lors de la création de la commande");
     } finally {
       setProcessing(false);
-      console.log("✅ Traitement terminé");
     }
   };
 

--- a/T-Express-Frontend/src/components/Payment/OrangeMoneyPayment.tsx
+++ b/T-Express-Frontend/src/components/Payment/OrangeMoneyPayment.tsx
@@ -50,10 +50,7 @@ export default function OrangeMoneyPayment({
         cancel_url: `${window.location.origin}/checkout`,
       };
 
-      console.log('🍊 Initiation paiement Orange Money:', data);
       const response = await paiementService.initierOrangeMoney(data);
-
-      console.log('🍊 Réponse Orange Money:', response);
 
       if (response.success) {
         // Si on a une URL de paiement, rediriger
@@ -74,7 +71,7 @@ export default function OrangeMoneyPayment({
         toast.error(response.message || 'Erreur lors de l\'initialisation du paiement');
       }
     } catch (error: any) {
-      console.error('❌ Erreur paiement Orange Money:', error);
+      console.error('Erreur paiement Orange Money:', error?.message || error);
       toast.error(error.message || 'Erreur lors du paiement Orange Money');
       setLoading(false);
     }

--- a/T-Express-Frontend/src/components/Payment/WavePayment.tsx
+++ b/T-Express-Frontend/src/components/Payment/WavePayment.tsx
@@ -50,10 +50,7 @@ export default function WavePayment({
         cancel_url: `${window.location.origin}/checkout`,
       };
 
-      console.log('📱 Initiation paiement Wave:', data);
       const response = await paiementService.initierWave(data);
-
-      console.log('📱 Réponse Wave:', response);
 
       // Le backend retourne wave_launch_url pour ouvrir l'app Wave
       if (response.wave_launch_url) {
@@ -77,8 +74,8 @@ export default function WavePayment({
         toast.error(response.message || 'Aucune URL de paiement retournée');
       }
     } catch (error: any) {
-      console.error('❌ Erreur paiement Wave:', error);
-      
+      console.error('Erreur paiement Wave:', error?.message || error);
+
       // Gestion améliorée des messages d'erreur
       let errorMessage = 'Erreur lors du paiement Wave';
       


### PR DESCRIPTION
## Probleme
`CheckoutNew.tsx`, `WavePayment.tsx` et `OrangeMoneyPayment.tsx` journalisaient en clair dans la console du navigateur, a chaque tentative de paiement (donc en production, pour chaque client), le detail complet des requetes/reponses API : numero de telephone, adresse, ID de commande, montant.

## Correction
- Retrait des `console.log()` de tracage etape par etape (bruit de debogage sans valeur en production)
- Les `console.error()` utiles en cas d'echec reel sont conserves mais simplifies pour ne loguer que le message d'erreur plutot que l'objet complet (qui pouvait contenir la charge utile de la requete)

Closes #41