### PR TITLE
fix: crash JSON.parse sur produit.images qui vidait le catalogue

### DIFF
--- a/T-Express-Frontend/src/types/adapters.ts
+++ b/T-Express-Frontend/src/types/adapters.ts
@@ -13,17 +13,31 @@ export function adaptProduitToProduct(produit: Produit): Product {
   // Construire les URLs des images
   const baseUrl = process.env.NEXT_PUBLIC_API_URL?.replace('/api', '') || '';
   const storagePath = `${baseUrl}/storage/`;
-  
+
+  // Le backend renvoie image_principale déjà en URL absolue, et images soit en
+  // tableau soit (anciennes données) en chaîne JSON : on gère les deux, et on
+  // ne préfixe que les chemins relatifs pour éviter de doubler l'origine.
+  const toUrl = (img: string) => (/^https?:\/\//i.test(img) ? img : `${storagePath}${img}`);
+
   const fallback = '/images/products/product-1-bg-1.png';
-  const images = produit.images ? JSON.parse(produit.images as any) : [];
-  const thumbnails = images.length > 0 
-    ? images.map((img: string) => `${storagePath}${img}`)
+  let images: string[] = [];
+  if (Array.isArray(produit.images)) {
+    images = produit.images;
+  } else if (typeof produit.images === 'string' && produit.images) {
+    try {
+      images = JSON.parse(produit.images);
+    } catch {
+      images = [];
+    }
+  }
+  const thumbnails = images.length > 0
+    ? images.map(toUrl)
     : [fallback];
   const previews = thumbnails; // Utiliser les mêmes images pour les previews
-  
+
   // Si on a une image principale, l'utiliser en premier
   if (produit.image_principale) {
-    const mainImage = `${storagePath}${produit.image_principale}`;
+    const mainImage = toUrl(produit.image_principale);
     thumbnails.unshift(mainImage);
     previews.unshift(mainImage);
   }


### PR DESCRIPTION
## Résumé
- Le backend renvoie `produit.images` comme tableau déjà décodé, pas comme chaîne JSON. `adaptProduitToProduct` appelait `JSON.parse()` dessus sans condition, ce qui levait une `SyntaxError` sur tout produit avec `images: []`.
- Cette exception, avalée silencieusement par le try/catch des composants appelants, vidait entièrement les sections Nouveautés, Meilleures ventes et les pages boutique (`shop-with-sidebar`, `shop-without-sidebar`) — trouvé en production après la bascule backend Render → VPS.
- Corrige aussi le préfixage d'URL : `image_principale` est déjà une URL absolue, la concaténer avec `storagePath` produisait une URL doublée et cassée.

## Test plan
- [x] Vérifié en local que l'API renvoie `images` comme tableau (`[]`), pas comme string.
- [x] Déployé sur le VPS de production, rebuild confirmé sans erreur.
- [ ] Vérifier visuellement que les sections Nouveautés/Meilleures ventes et les pages boutique affichent bien les produits après ce déploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)