### PR TITLE
fix: telephone obligatoire au checkout cote client (coordination backend #60)

### DIFF
--- a/T-Express-Frontend/src/components/Checkout/CheckoutNew.tsx
+++ b/T-Express-Frontend/src/components/Checkout/CheckoutNew.tsx
@@ -108,8 +108,15 @@ const CheckoutNew = () => {
       // Créer une nouvelle adresse si nécessaire
       let adresseId = selectedAdresseId;
       if (showNewAddress && newAddress.adresse_ligne_1) {
-        // Valider le téléphone si fourni
-        if (newAddress.telephone && !validatePhone(newAddress.telephone)) {
+        // Le backend exige desormais le telephone sur une adresse (utilise pour le
+        // suivi WhatsApp de la commande) : le verifier ici evite un aller-retour API
+        // qui echouerait avec 422 pour un champ que le formulaire laissait optionnel.
+        if (!newAddress.telephone) {
+          toast.error("Le numéro de téléphone est obligatoire pour la livraison");
+          setProcessing(false);
+          return;
+        }
+        if (!validatePhone(newAddress.telephone)) {
           toast.error("Le numéro de téléphone n'est pas valide. Format attendu : +221 XX XXX XX XX");
           setProcessing(false);
           return;


### PR DESCRIPTION
## Résumé
Le backend rend `telephone` obligatoire à la création d'une adresse (PR #60 backend, ticket #11), mais le formulaire de checkout ne validait le format que si le champ était rempli — rien n'empêchait de le laisser vide. Sans ce correctif, un client qui saute le champ obtient un 422 après soumission au lieu d'un message clair avant l'appel API.

## Test plan
- [x] Lecture du composant `PhoneInput` : gère déjà l'astérisque visuel et la validation interne quand `required`.
- [ ] Vérifier manuellement que soumettre le checkout sans téléphone affiche le message d'erreur avant l'appel réseau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)