### PR TITLE
fix: corrige l'incoherence des frais de livraison au checkout (#4)

### DIFF
--- a/T-Express-Frontend/src/components/Checkout/CheckoutNew.tsx
+++ b/T-Express-Frontend/src/components/Checkout/CheckoutNew.tsx
@@ -78,8 +78,12 @@ const CheckoutNew = () => {
     loadAdresses();
   }, [user]);
 
-  // Calculer les frais de livraison - LIVRAISON GRATUITE
-  const shippingCost = 0;
+  // Calculer les frais de livraison selon la méthode choisie
+  const SHIPPING_COSTS: Record<"standard" | "express", number> = {
+    standard: 2000,
+    express: 5000,
+  };
+  const shippingCost = SHIPPING_COSTS[shippingMethod];
   const totalWithShipping = (panier?.total || 0) + shippingCost;
 
   // Soumettre la commande
@@ -145,7 +149,7 @@ const CheckoutNew = () => {
         adresse_facturation_id: adresseId,
         mode_paiement: (paymentMethod === "especes" ? "cash" : paymentMethod) as "wave" | "orange_money" | "cash" | "carte",
         notes: notes || undefined,
-        frais_livraison: shippingMethod === "express" ? 5000 : 2000
+        frais_livraison: shippingCost
       };
 
       const commande = await commandeService.creer(commandeData);
@@ -372,7 +376,7 @@ const CheckoutNew = () => {
 
                     <div className="flex items-center justify-between py-5 border-b border-gray-3">
                       <p className="text-dark">Frais de livraison</p>
-                      <p className="text-green-600 font-semibold text-right">Gratuite ✓</p>
+                      <p className="text-dark font-semibold text-right">{formatPrice(shippingCost)}</p>
                     </div>
 
                     <div className="flex items-center justify-between pt-5">
@@ -384,7 +388,7 @@ const CheckoutNew = () => {
                   </div>
                 </div>
 
-               {/* Méthode de livraison - Gratuite */}
+               {/* Méthode de livraison */}
                 <div className="bg-white shadow-1 rounded-[10px] mt-7.5">
                   <div className="border-b border-gray-3 py-5 px-4 sm:px-8.5">
                     <h3 className="font-medium text-xl text-dark">Méthode de livraison</h3>
@@ -401,8 +405,8 @@ const CheckoutNew = () => {
                           onChange={(e) => setShippingMethod(e.target.value as "standard")}
                           className="w-4 h-4"
                         />
-                        <div className="flex-1 rounded-md border py-3.5 px-5 border-green-200 bg-green-50">
-                          <p className="text-green-700 font-medium">🚚 Livraison Standard - <span className="font-bold">Gratuite</span> (3-5 jours)</p>
+                        <div className="flex-1 rounded-md border py-3.5 px-5 border-gray-4">
+                          <p className="text-dark font-medium">🚚 Livraison Standard - <span className="font-bold">{formatPrice(SHIPPING_COSTS.standard)}</span> (3-5 jours)</p>
                         </div>
                       </label>
                     </div>


### PR DESCRIPTION
## Problème
Le total affiché au client au checkout utilisait `shippingCost = 0` (codé en dur), affichant "Frais de livraison : Gratuite". Pourtant, à la soumission, la commande envoyée au backend contenait `frais_livraison: 2000` (standard) ou `5000` (express) — incohérence entre prix affiché et prix réellement facturé.

## Solution
- Les frais de livraison sont maintenant calculés dynamiquement selon la méthode choisie (`SHIPPING_COSTS`), au lieu d'être codés en dur à 0
- Le montant envoyé au backend (`frais_livraison`) réutilise cette même variable (`shippingCost`) — une seule source de vérité, impossible de désynchroniser à nouveau
- L'affichage "Frais de livraison" dans le résumé de commande montre désormais le vrai montant au lieu de "Gratuite ✓"
- Le texte "Livraison Standard - Gratuite" a aussi été corrigé pour afficher le vrai prix

## Non traité dans cette PR
La 2e tâche du ticket (vérifier la cohérence avec le message WhatsApp du "ticket de remplacement de paiement") n'a pas pu être traitée : aucun code de ce type (fallback WhatsApp pour paiement échoué) n'existe actuellement dans la codebase. À clarifier avec @MbayeSyAmar si ce système existe ailleurs ou est prévu dans un autre ticket. @Estherdevdiop @CodeNinja-lab @Amar233-ui 