### PR TITLE
fix: verification de la longueur et de la confirmation du mot de passe a l'inscription (#26)

### DIFF
--- a/T-Express-Frontend/src/components/Auth/Signup/index.tsx
+++ b/T-Express-Frontend/src/components/Auth/Signup/index.tsx
@@ -7,6 +7,9 @@ import { useRouter } from "next/navigation";
 import PhoneInput from "@/components/Common/PhoneInput";
 import { validatePhone } from "@/lib/utils";
 
+// Aligné sur la règle backend (RegisterRequest : password min:8).
+const LONGUEUR_MIN_MOT_DE_PASSE = 8;
+
 const Signup = () => {
   const [formData, setFormData] = useState({
     nom: "",
@@ -20,6 +23,10 @@ const Signup = () => {
   const { register, registerLoading } = useAuthContext();
   const router = useRouter();
   const [error, setError] = useState<string>("");
+
+  // Signalé dès la saisie de la confirmation, sans attendre l'envoi.
+  const confirmationDifferente =
+    formData.password_confirmation.length > 0 && formData.password !== formData.password_confirmation;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData(prev => ({
@@ -37,7 +44,17 @@ const Signup = () => {
       setError("Le numéro de téléphone n'est pas valide. Format attendu : +221 XX XXX XX XX");
       return;
     }
-    
+
+    if (formData.password.length < LONGUEUR_MIN_MOT_DE_PASSE) {
+      setError(`Le mot de passe doit contenir au moins ${LONGUEUR_MIN_MOT_DE_PASSE} caractères.`);
+      return;
+    }
+
+    if (formData.password !== formData.password_confirmation) {
+      setError("Les deux mots de passe ne correspondent pas.");
+      return;
+    }
+
     // Adapter les noms de champs pour l'API Laravel
     const data = {
       nom: formData.nom,
@@ -74,7 +91,7 @@ const Signup = () => {
             <div>
               <form onSubmit={handleSubmit}>
                 {error && (
-                  <div className="mb-5 p-4 bg-red-50 border border-red-200 text-red-600 rounded-lg">
+                  <div role="alert" className="mb-5 p-4 bg-red-light-6 border border-red-light-4 text-red rounded-lg">
                     {error}
                   </div>
                 )}
@@ -151,11 +168,15 @@ const Signup = () => {
                     id="password"
                     placeholder="Votre mot de passe"
                     autoComplete="new-password"
+                    aria-describedby="password-aide"
                     value={formData.password}
                     onChange={handleChange}
                     required
                     className="rounded-lg border border-gray-3 bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20"
                   />
+                  <p id="password-aide" className="mt-1.5 text-custom-sm text-dark-5">
+                    {LONGUEUR_MIN_MOT_DE_PASSE} caractères minimum.
+                  </p>
                 </div>
 
                 <div className="mb-5">
@@ -168,11 +189,18 @@ const Signup = () => {
                     id="password_confirmation"
                     placeholder="Confirmez votre mot de passe"
                     autoComplete="new-password"
+                    aria-invalid={confirmationDifferente}
+                    aria-describedby="password-confirmation-aide"
                     value={formData.password_confirmation}
                     onChange={handleChange}
                     required
-                    className="rounded-lg border border-gray-3 bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20"
+                    className={`rounded-lg border bg-gray-1 placeholder:text-dark-5 w-full py-3 px-5 outline-none duration-200 focus:border-transparent focus:shadow-input focus:ring-2 focus:ring-blue/20 ${
+                      confirmationDifferente ? "border-red" : "border-gray-3"
+                    }`}
                   />
+                  <p id="password-confirmation-aide" aria-live="polite" className="mt-1.5 text-custom-sm text-red">
+                    {confirmationDifferente ? "Les deux mots de passe ne correspondent pas." : ""}
+                  </p>
                 </div>
 
                 <button


### PR DESCRIPTION
Closes #26

## Problème
L'inscription partait sans vérifier que `password` et `password_confirmation` correspondaient, ni leur longueur. L'erreur n'était vue que côté serveur, alors que le changement de mot de passe dans `MyAccountNew.tsx` fait déjà cette vérification.

## Ce qui change
- Refus **avant l'appel à `register()`** si le mot de passe fait moins de **8 caractères** (même règle que `RegisterRequest` côté backend : `min:8`) ou si la confirmation diffère, avec un message clair.
- Aide sous les champs : « 8 caractères minimum ». La non-correspondance est signalée dès la saisie de la confirmation (bordure rouge, `aria-invalid`, message `aria-live`).
- **Bug corrigé au passage** : le bandeau d'erreur utilisait `bg-red-50`, `border-red-200` et `text-red-600`, absents du thème Tailwind (la palette y est redéfinie). Toutes les erreurs d'inscription s'affichaient donc sans aucun style. Il utilise maintenant les tokens `red` du thème, avec `role="alert"`.

## Tests (Edge + backend local)
- [x] mot de passe de 5 caractères → message, **0 appel** à `/auth/register`
- [x] mots de passe différents → aide en direct + message, **0 appel**
- [x] mots de passe valides et identiques → 1 appel, compte créé, redirection vers `/`
- [x] `tsc --noEmit` et ESLint sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
