### PR TITLE
feat: pages confidentialite, CGU, remboursement et FAQ (#14)

### DIFF
--- a/T-Express-Frontend/src/app/(site)/(pages)/faq/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/faq/page.tsx
@@ -1,0 +1,123 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import LegalPage from "@/components/Legal/LegalPage";
+import { LEGAL } from "@/config/legal";
+
+export const metadata: Metadata = {
+  title: "FAQ | T-Express",
+  description: "Questions fréquentes : commander, payer, se faire livrer, suivre ou retourner une commande T-Express.",
+};
+
+const lien = "text-blue hover:underline";
+
+const QUESTIONS: { question: string; reponse: React.ReactNode }[] = [
+  {
+    question: "Comment passer commande ?",
+    reponse: (
+      <>
+        Ajoutez vos produits au panier, puis cliquez sur « Passer la commande ». Renseignez votre adresse de
+        livraison et cliquez sur « Valider la commande » : la commande est enregistrée et un bouton vous permet
+        d&apos;envoyer son récapitulatif à notre équipe sur WhatsApp. Elle vous répond pour confirmer la commande.
+      </>
+    ),
+  },
+  {
+    question: "Faut-il créer un compte ?",
+    reponse: (
+      <>
+        Oui, un compte est nécessaire pour commander : il permet de retrouver vos adresses et de suivre vos
+        commandes. L&apos;inscription se fait sur la page{" "}
+        <Link href="/signup" className={lien}>
+          Inscription
+        </Link>
+        .
+      </>
+    ),
+  },
+  {
+    question: "Comment payer ma commande ?",
+    reponse: (
+      <>
+        Aucun paiement n&apos;est demandé sur le site. Le moyen et le moment du paiement sont convenus avec notre
+        équipe sur WhatsApp, au moment où elle confirme votre commande.
+      </>
+    ),
+  },
+  {
+    question: "Combien coûte la livraison et combien de temps prend-elle ?",
+    reponse: (
+      <>
+        La livraison standard est actuellement gratuite, avec un délai indicatif de {LEGAL.delaiLivraison} après
+        la confirmation de la commande.
+      </>
+    ),
+  },
+  {
+    question: "Comment suivre ma commande ?",
+    reponse: (
+      <>
+        Retrouvez vos commandes et leur statut dans{" "}
+        <Link href="/my-account/orders" className={lien}>
+          Mon compte › Mes commandes
+        </Link>
+        . Pour toute précision, écrivez-nous sur WhatsApp avec votre numéro de commande.
+      </>
+    ),
+  },
+  {
+    question: "Puis-je modifier ou annuler ma commande ?",
+    reponse: (
+      <>
+        Oui, tant qu&apos;elle n&apos;a pas été expédiée : contactez-nous sur WhatsApp ({LEGAL.whatsappAffiche}) en
+        indiquant votre numéro de commande.
+      </>
+    ),
+  },
+  {
+    question: "Le produit reçu ne me convient pas ou est abîmé, que faire ?",
+    reponse: (
+      <>
+        Vous pouvez demander un retour dans les {LEGAL.delaiRetourJours} jours suivant la livraison, et signaler un
+        produit abîmé ou non conforme dans les {LEGAL.delaiSignalementHeures} heures. Toutes les conditions sont
+        dans notre{" "}
+        <Link href="/refund-policy" className={lien}>
+          politique de remboursement
+        </Link>
+        .
+      </>
+    ),
+  },
+  {
+    question: "Mes données personnelles sont-elles protégées ?",
+    reponse: (
+      <>
+        Oui. Nous ne collectons que ce qui est nécessaire pour traiter vos commandes et ne vendons jamais vos
+        données. Le détail figure dans notre{" "}
+        <Link href="/privacy" className={lien}>
+          politique de confidentialité
+        </Link>
+        .
+      </>
+    ),
+  },
+];
+
+const FaqPage = () => (
+  <LegalPage titre="Questions fréquentes" fil="FAQ">
+    <div className="divide-y divide-gray-3 border-y border-gray-3">
+      {QUESTIONS.map(({ question, reponse }) => (
+        <details key={question} className="group py-4">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-4 font-medium text-dark [&::-webkit-details-marker]:hidden">
+            {question}
+            <span aria-hidden="true" className="text-xl text-blue transition-transform duration-200 group-open:rotate-45">
+              +
+            </span>
+          </summary>
+          <p className="mt-3">{reponse}</p>
+        </details>
+      ))}
+    </div>
+  </LegalPage>
+);
+
+export default FaqPage;

--- a/T-Express-Frontend/src/app/(site)/(pages)/privacy/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/privacy/page.tsx
@@ -1,0 +1,121 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import LegalPage, { Liste, Section } from "@/components/Legal/LegalPage";
+
+export const metadata: Metadata = {
+  title: "Politique de confidentialité | T-Express",
+  description: "Quelles données T-Express collecte, pourquoi, combien de temps, et comment exercer vos droits.",
+};
+
+const PrivacyPage = () => (
+  <LegalPage
+    titre="Politique de confidentialité"
+    fil="confidentialité"
+    intro={
+      <p>
+        Cette page explique quelles données personnelles T-Express collecte lorsque vous utilisez le site,
+        à quoi elles servent et comment exercer vos droits, conformément à la loi sénégalaise n° 2008-12 du
+        25 janvier 2008 sur la protection des données à caractère personnel.
+      </p>
+    }
+  >
+    <Section titre="1. Responsable du traitement">
+      <p>
+        Les données sont traitées par T-Express, boutique en ligne exploitée au Sénégal. Pour toute question
+        sur vos données, contactez-nous (coordonnées en bas de page).
+      </p>
+    </Section>
+
+    <Section titre="2. Données collectées">
+      <Liste>
+        <li>
+          <strong>Compte :</strong> nom, prénom, adresse e-mail, téléphone, mot de passe (enregistré chiffré,
+          jamais en clair) et, si vous la renseignez, date de naissance.
+        </li>
+        <li>
+          <strong>Livraison :</strong> nom du destinataire, adresse, ville et téléphone.
+        </li>
+        <li>
+          <strong>Activité sur le site :</strong> commandes, panier, produits favoris et avis publiés.
+        </li>
+        <li>
+          <strong>Données techniques :</strong> un jeton de connexion conservé dans votre navigateur pour vous
+          garder connecté. Le site n&apos;utilise pas de cookies publicitaires.
+        </li>
+      </Liste>
+      <p>
+        Le site n&apos;enregistre aucune donnée bancaire : le paiement est convenu directement avec notre équipe
+        lors de la confirmation de la commande.
+      </p>
+    </Section>
+
+    <Section titre="3. Pourquoi nous les utilisons">
+      <Liste>
+        <li>créer et gérer votre compte ;</li>
+        <li>traiter, confirmer et livrer vos commandes, et gérer les éventuels retours ;</li>
+        <li>vous contacter au sujet de vos commandes et répondre à vos demandes ;</li>
+        <li>afficher vos avis sur les produits ;</li>
+        <li>assurer la sécurité du site et prévenir la fraude.</li>
+      </Liste>
+      <p>Vos données ne sont jamais vendues ni utilisées à des fins publicitaires par des tiers.</p>
+    </Section>
+
+    <Section titre="4. Qui y a accès">
+      <Liste>
+        <li>l&apos;équipe T-Express, pour le traitement des commandes et le service client ;</li>
+        <li>
+          le cas échéant, le livreur, uniquement pour les informations nécessaires à la livraison (nom,
+          téléphone, adresse) ;
+        </li>
+        <li>notre hébergeur, qui stocke les données du site pour notre compte.</li>
+      </Liste>
+      <p>
+        Lorsque vous finalisez une commande, le récapitulatif est envoyé par vous-même sur WhatsApp : ce message
+        est alors aussi traité par WhatsApp selon sa propre politique de confidentialité.
+      </p>
+      <p>
+        Sur les avis publiés, seuls votre prénom et l&apos;initiale de votre nom apparaissent publiquement.
+      </p>
+    </Section>
+
+    <Section titre="5. Durée de conservation">
+      <p>
+        Les données de votre compte sont conservées tant qu&apos;il est actif. Les informations liées aux
+        commandes sont conservées le temps nécessaire à leur suivi (livraison, retours, service client) et au
+        respect de nos obligations légales et comptables.
+      </p>
+    </Section>
+
+    <Section titre="6. Sécurité">
+      <p>
+        Les échanges avec le site sont chiffrés (HTTPS) et les mots de passe sont stockés sous forme chiffrée.
+        Gardez votre mot de passe confidentiel et déconnectez-vous sur un appareil partagé.
+      </p>
+    </Section>
+
+    <Section titre="7. Vos droits">
+      <p>
+        Vous pouvez à tout moment demander l&apos;accès à vos données, leur rectification ou leur suppression,
+        et vous opposer à leur traitement pour un motif légitime. Une partie de ces informations est modifiable
+        directement depuis{" "}
+        <Link href="/my-account" className="text-blue hover:underline">
+          votre compte
+        </Link>
+        . Pour le reste, contactez-nous : nous vous répondrons dans les meilleurs délais.
+      </p>
+      <p>
+        Si vous estimez que vos droits ne sont pas respectés, vous pouvez saisir la Commission de Protection
+        des Données Personnelles (CDP) du Sénégal.
+      </p>
+    </Section>
+
+    <Section titre="8. Modifications">
+      <p>
+        Cette politique peut évoluer, par exemple si le site propose de nouveaux services. La date de dernière
+        mise à jour figure en haut de cette page.
+      </p>
+    </Section>
+  </LegalPage>
+);
+
+export default PrivacyPage;

--- a/T-Express-Frontend/src/app/(site)/(pages)/refund-policy/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/refund-policy/page.tsx
@@ -1,0 +1,72 @@
+import { Metadata } from "next";
+import LegalPage, { Liste, Section } from "@/components/Legal/LegalPage";
+import { LEGAL } from "@/config/legal";
+
+export const metadata: Metadata = {
+  title: "Politique de remboursement | T-Express",
+  description: "Retours, échanges et remboursements chez T-Express : délais, conditions et démarche.",
+};
+
+const RefundPolicyPage = () => (
+  <LegalPage
+    titre="Politique de remboursement"
+    fil="remboursement"
+    intro={
+      <p>
+        Un produit ne vous convient pas ou est arrivé abîmé ? Voici comment demander un retour, un échange ou un
+        remboursement.
+      </p>
+    }
+  >
+    <Section titre="1. Produit abîmé, défectueux ou non conforme">
+      <p>
+        Signalez-le-nous <strong>dans les {LEGAL.delaiSignalementHeures} heures suivant la livraison</strong>,
+        avec votre numéro de commande et des photos du produit et de l&apos;emballage. Après vérification, nous
+        vous proposons un échange ou un remboursement, sans frais pour vous.
+      </p>
+    </Section>
+
+    <Section titre="2. Retour d'un produit qui ne vous convient pas">
+      <p>
+        Vous pouvez demander un retour <strong>dans les {LEGAL.delaiRetourJours} jours suivant la livraison</strong>,
+        si le produit :
+      </p>
+      <Liste>
+        <li>n&apos;a pas été utilisé, lavé ni endommagé ;</li>
+        <li>est complet (accessoires, notices) et dans son emballage d&apos;origine.</li>
+      </Liste>
+      <p>
+        Pour des raisons d&apos;hygiène, certains articles ne peuvent pas être repris une fois ouverts (par
+        exemple les produits de soin ou les écouteurs intra-auriculaires) ; ce sera précisé lors de votre
+        demande.
+      </p>
+    </Section>
+
+    <Section titre="3. Comment faire une demande">
+      <Liste>
+        <li>
+          Contactez-nous sur WhatsApp ({LEGAL.whatsappAffiche}) ou via la page Contact, en indiquant votre numéro
+          de commande, le ou les produits concernés et la raison du retour.
+        </li>
+        <li>Notre équipe examine la demande et vous répond pour l&apos;accepter ou l&apos;expliquer si elle est refusée.</li>
+        <li>Si elle est acceptée, nous convenons avec vous de la reprise du produit.</li>
+      </Liste>
+    </Section>
+
+    <Section titre="4. Remboursement">
+      <p>
+        Une fois le produit reçu et vérifié, le remboursement est effectué par le moyen de paiement convenu avec
+        vous, dans les meilleurs délais. Vous pouvez aussi choisir un échange contre un autre produit.
+      </p>
+    </Section>
+
+    <Section titre="5. Annulation avant livraison">
+      <p>
+        Vous pouvez annuler une commande tant qu&apos;elle n&apos;a pas été expédiée, en nous contactant sur
+        WhatsApp. Si un paiement a déjà été effectué, il vous est intégralement remboursé.
+      </p>
+    </Section>
+  </LegalPage>
+);
+
+export default RefundPolicyPage;

--- a/T-Express-Frontend/src/app/(site)/(pages)/terms/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/terms/page.tsx
@@ -1,0 +1,122 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import LegalPage, { Liste, Section } from "@/components/Legal/LegalPage";
+import { LEGAL } from "@/config/legal";
+
+export const metadata: Metadata = {
+  title: "Conditions d'utilisation | T-Express",
+  description: "Conditions d'utilisation du site T-Express : compte, commandes, prix, livraison et retours.",
+};
+
+const TermsPage = () => (
+  <LegalPage
+    titre="Conditions d'utilisation"
+    fil="conditions d'utilisation"
+    intro={
+      <p>
+        Les présentes conditions encadrent l&apos;utilisation du site T-Express et les commandes qui y sont
+        passées. En créant un compte ou en passant commande, vous les acceptez.
+      </p>
+    }
+  >
+    <Section titre="1. Le service">
+      <p>
+        T-Express est une boutique en ligne exploitée au Sénégal. Le site présente un catalogue de produits
+        et permet de passer commande ; chaque commande est ensuite confirmée par notre équipe sur WhatsApp.
+      </p>
+    </Section>
+
+    <Section titre="2. Compte client">
+      <Liste>
+        <li>Un compte est nécessaire pour passer commande.</li>
+        <li>
+          Vous vous engagez à fournir des informations exactes, notamment votre téléphone et votre adresse de
+          livraison, indispensables pour vous livrer.
+        </li>
+        <li>
+          Vous êtes responsable de la confidentialité de votre mot de passe et des actions réalisées avec votre
+          compte.
+        </li>
+      </Liste>
+    </Section>
+
+    <Section titre="3. Commandes">
+      <p>
+        Après validation du panier, la commande est enregistrée et vous envoyez son récapitulatif à notre équipe
+        sur WhatsApp. <strong>La commande est définitive une fois confirmée par notre équipe</strong>, qui
+        convient alors avec vous du paiement et de la livraison.
+      </p>
+      <p>
+        T-Express peut refuser ou annuler une commande, par exemple en cas de produit indisponible,
+        d&apos;informations de livraison incomplètes ou de commande manifestement anormale. Vous en êtes
+        informé et aucun montant ne vous est dû dans ce cas.
+      </p>
+    </Section>
+
+    <Section titre="4. Prix et disponibilité">
+      <p>
+        Les prix sont indiqués en francs CFA (FCFA). Le prix appliqué est celui affiché au moment de la
+        commande. Les produits sont proposés dans la limite des stocks disponibles ; malgré notre attention, une
+        erreur d&apos;affichage reste possible et vous serait signalée avant confirmation.
+      </p>
+    </Section>
+
+    <Section titre="5. Paiement">
+      <p>
+        Aucun paiement n&apos;est effectué sur le site. Le moyen et le moment du paiement sont convenus avec
+        notre équipe lors de la confirmation de la commande sur WhatsApp.
+      </p>
+    </Section>
+
+    <Section titre="6. Livraison">
+      <p>
+        La livraison standard est actuellement gratuite, avec un délai indicatif de {LEGAL.delaiLivraison} après
+        confirmation. Ce délai peut varier selon la destination ; nous vous prévenons en cas de retard.
+      </p>
+    </Section>
+
+    <Section titre="7. Retours et remboursements">
+      <p>
+        Les conditions de retour, d&apos;échange et de remboursement sont détaillées dans notre{" "}
+        <Link href="/refund-policy" className="text-blue hover:underline">
+          politique de remboursement
+        </Link>
+        .
+      </p>
+    </Section>
+
+    <Section titre="8. Avis clients">
+      <p>
+        Les avis doivent porter sur le produit et rester respectueux. T-Express peut retirer un avis injurieux,
+        hors sujet ou contenant des informations personnelles.
+      </p>
+    </Section>
+
+    <Section titre="9. Propriété intellectuelle">
+      <p>
+        Les éléments du site (logo, textes, visuels) appartiennent à T-Express ou à leurs titulaires et ne
+        peuvent pas être réutilisés sans autorisation.
+      </p>
+    </Section>
+
+    <Section titre="10. Données personnelles">
+      <p>
+        Le traitement de vos données est décrit dans notre{" "}
+        <Link href="/privacy" className="text-blue hover:underline">
+          politique de confidentialité
+        </Link>
+        .
+      </p>
+    </Section>
+
+    <Section titre="11. Droit applicable et litiges">
+      <p>
+        Ces conditions sont soumises au droit sénégalais. En cas de difficulté, contactez-nous d&apos;abord :
+        nous chercherons une solution amiable. À défaut, le litige sera porté devant les juridictions
+        compétentes du Sénégal.
+      </p>
+    </Section>
+  </LegalPage>
+);
+
+export default TermsPage;

--- a/T-Express-Frontend/src/components/Footer/index.tsx
+++ b/T-Express-Frontend/src/components/Footer/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { apiClient } from "@/lib/api-client";
 import { API_CONFIG } from "@/config/api.config";
 
@@ -288,24 +289,24 @@ const Footer = () => {
 
             <ul className="flex flex-col gap-3">
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/privacy">
                   Politique de confidentialité
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/refund-policy">
                   Politique de remboursement
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/terms">
                   Conditions d&apos;utilisation
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/faq">
                   FAQ
-                </a>
+                </Link>
               </li>
               <li>
                 <a className="ease-out duration-200 hover:text-blue" href="#">

--- a/T-Express-Frontend/src/components/Legal/LegalPage.tsx
+++ b/T-Express-Frontend/src/components/Legal/LegalPage.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import Link from "next/link";
+import Breadcrumb from "@/components/Common/Breadcrumb";
+import { LEGAL } from "@/config/legal";
+import { ADMIN_WHATSAPP_NUMBER } from "@/lib/whatsapp";
+
+/** Gabarit commun des pages légales et de la FAQ. */
+const LegalPage = ({
+  titre,
+  fil,
+  intro,
+  children,
+}: {
+  titre: string;
+  fil: string;
+  intro?: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <main>
+    <Breadcrumb title={titre} pages={[fil]} />
+    <section className="overflow-hidden py-20 bg-gray-2">
+      <div className="max-w-[870px] w-full mx-auto px-4 sm:px-8 xl:px-0">
+        <article className="bg-white rounded-xl shadow-1 px-4 py-8 sm:p-10 xl:p-12.5 text-dark-2 leading-relaxed">
+          <p className="text-custom-sm text-dark-4 mb-6">Dernière mise à jour : {LEGAL.miseAJour}</p>
+          {intro && <div className="mb-8 text-dark">{intro}</div>}
+          <div className="space-y-8">{children}</div>
+          <p className="mt-10 pt-6 border-t border-gray-3 text-custom-sm">
+            Une question ? Écrivez-nous sur{" "}
+            <a
+              href={`https://wa.me/${ADMIN_WHATSAPP_NUMBER}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue hover:underline"
+            >
+              WhatsApp ({LEGAL.whatsappAffiche})
+            </a>{" "}
+            ou via la page{" "}
+            <Link href="/contact" className="text-blue hover:underline">
+              Contact
+            </Link>
+            .
+          </p>
+        </article>
+      </div>
+    </section>
+  </main>
+);
+
+/** Section titrée d'une page légale. */
+export const Section = ({ titre, children }: { titre: string; children: React.ReactNode }) => (
+  <section>
+    <h2 className="font-semibold text-dark text-lg sm:text-custom-1 mb-3">{titre}</h2>
+    <div className="space-y-3">{children}</div>
+  </section>
+);
+
+/** Liste à puces homogène entre les pages. */
+export const Liste = ({ children }: { children: React.ReactNode }) => (
+  <ul className="list-disc pl-5 space-y-1.5">{children}</ul>
+);
+
+export default LegalPage;

--- a/T-Express-Frontend/src/config/legal.ts
+++ b/T-Express-Frontend/src/config/legal.ts
@@ -1,0 +1,15 @@
+/**
+ * Valeurs reprises dans les pages légales (confidentialité, CGU,
+ * remboursement, FAQ). Ce sont des engagements commerciaux : les modifier
+ * ici les met à jour partout, et penser à changer la date de mise à jour.
+ */
+export const LEGAL = {
+  miseAJour: "11 septembre 2026",
+  /** Délai, après la livraison, pour demander un retour. */
+  delaiRetourJours: 7,
+  /** Délai pour signaler un produit abîmé ou non conforme. */
+  delaiSignalementHeures: 48,
+  /** Délai de livraison standard annoncé au checkout. */
+  delaiLivraison: "3 à 5 jours ouvrés",
+  whatsappAffiche: "+221 77 118 87 47",
+} as const;


### PR DESCRIPTION
Closes #14

## Problème
Le footer listait « Politique de confidentialité », « Politique de remboursement », « Conditions d'utilisation » et « FAQ » en `href="#"`, et aucune de ces pages n'existait. Pour un site qui prend de vraies commandes, c'est un manque légal.

## Ce qui change
Quatre pages, rédigées pour le Sénégal et pour **le fonctionnement réel du site** (vérifié dans le code, rien d'inventé sur le parcours) :

| Route | Contenu |
|---|---|
| `/privacy` | données collectées (compte, livraison, activité, jeton de connexion, aucune donnée bancaire), finalités, destinataires (équipe, livreur, hébergeur, WhatsApp pour le récapitulatif envoyé par le client), conservation, sécurité (HTTPS, mots de passe chiffrés), droits au titre de la **loi n° 2008-12**, recours auprès de la **CDP** |
| `/terms` | compte, commande **définitive à la confirmation sur WhatsApp**, prix en FCFA, paiement convenu avec l'équipe (aucun paiement sur le site), livraison, avis modérables, droit sénégalais |
| `/refund-policy` | produit abîmé ou non conforme, retour d'un produit qui ne convient pas, démarche (WhatsApp/Contact : il n'existe pas d'interface client pour les retours), remboursement, annulation avant expédition |
| `/faq` | 8 questions (commander, compte, paiement, livraison, suivi, annulation, retours, données), en `<details>` natifs : accessible, sans JavaScript |

- Gabarit commun `components/Legal/LegalPage.tsx` : fil d'Ariane, date de mise à jour, pied de page WhatsApp/Contact.
- Les 4 liens du footer pointent vers ces pages. Le lien « Contact » voisin et les autres `href="#"` relèvent du #22.

## ⚠️ À valider par la direction
Certains engagements commerciaux ne sont écrits nulle part dans le code. J'ai choisi des valeurs usuelles, **centralisées dans `src/config/legal.ts`** pour les modifier en un seul endroit :
- délai de retour : **7 jours** après livraison ;
- signalement d'un produit abîmé : **48 h** ;
- délai de livraison : **3 à 5 jours ouvrés** (repris du checkout).

Il faut aussi relire la mention « certains articles d'hygiène non repris une fois ouverts » et, si besoin, ajouter les mentions d'identification de l'entreprise (raison sociale, NINEA, RCCM), que je n'ai pas.

## Tests
- [x] les 4 routes répondent 200, avec `<title>` et `h1` corrects
- [x] liens du footer : `/privacy`, `/refund-policy`, `/terms`, `/faq`
- [x] l'accordéon FAQ s'ouvre
- [x] `tsc --noEmit` et ESLint sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
