### PR TITLE
fix: liens morts du footer et du header (#22)

### DIFF
--- a/T-Express-Frontend/src/components/Footer/index.tsx
+++ b/T-Express-Frontend/src/components/Footer/index.tsx
@@ -16,6 +16,17 @@ interface FooterSettings {
   linkedin_url: string;
 }
 
+// Coordonnées et réseaux viennent de l'API (settings). Tant que l'admin ne
+// les a pas saisis, ce sont des textes d'attente : ils ne doivent devenir ni
+// un lien tel:/mailto: invalide, ni une icône sociale pointant vers "#".
+const lienTelephone = (telephone: string) => {
+  const numero = telephone.replace(/[^\d+]/g, "");
+  return numero.replace(/\D/g, "").length >= 8 ? `tel:${numero}` : undefined;
+};
+const lienEmail = (email: string) =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim()) ? `mailto:${email.trim()}` : undefined;
+const estUrl = (url?: string) => !!url && /^https?:\/\//.test(url);
+
 const Footer = () => {
   const year = new Date().getFullYear();
   const [settings, setSettings] = useState<FooterSettings>({
@@ -23,10 +34,10 @@ const Footer = () => {
     telephone: "Téléphone à définir par l'administrateur",
     email: "Email à définir par l'administrateur",
     copyright: "Tous droits réservés. Contenu défini par l'administrateur.",
-    facebook_url: "#",
-    twitter_url: "#",
-    instagram_url: "#",
-    linkedin_url: "#",
+    facebook_url: "",
+    twitter_url: "",
+    instagram_url: "",
+    linkedin_url: "",
   });
 
   useEffect(() => {
@@ -80,7 +91,7 @@ const Footer = () => {
               </li>
 
               <li>
-                <a href="#" className="flex items-center gap-4.5">
+                <a href={lienTelephone(settings.telephone)} className="flex items-center gap-4.5">
                   <svg
                     width="24"
                     height="24"
@@ -110,7 +121,7 @@ const Footer = () => {
               </li>
 
               <li>
-                <a href="#" className="flex items-center gap-4.5">
+                <a href={lienEmail(settings.email)} className="flex items-center gap-4.5">
                   <svg
                     width="24"
                     height="24"
@@ -132,6 +143,7 @@ const Footer = () => {
 
             {/* <!-- Social Links start --> */}
             <div className="flex items-center gap-4 mt-7.5">
+              {estUrl(settings.facebook_url) && (
               <a
                 href={settings.facebook_url}
                 aria-label="Facebook Social Link"
@@ -158,7 +170,9 @@ const Footer = () => {
                   />
                 </svg>
               </a>
+              )}
 
+              {estUrl(settings.twitter_url) && (
               <a
                 href={settings.twitter_url}
                 aria-label="Twitter Social Link"
@@ -180,7 +194,9 @@ const Footer = () => {
                   />
                 </svg>
               </a>
+              )}
 
+              {estUrl(settings.instagram_url) && (
               <a
                 href={settings.instagram_url}
                 aria-label="Instagram Social Link"
@@ -217,7 +233,9 @@ const Footer = () => {
                   </defs>
                 </svg>
               </a>
+              )}
 
+              {estUrl(settings.linkedin_url) && (
               <a
                 href={settings.linkedin_url}
                 aria-label="Linkedin Social Link"
@@ -244,6 +262,7 @@ const Footer = () => {
                   />
                 </svg>
               </a>
+              )}
             </div>
             {/* <!-- Social Links end --> */}
           </div>
@@ -255,29 +274,29 @@ const Footer = () => {
 
             <ul className="flex flex-col gap-3.5">
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/my-account">
                   Mon compte
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/signin">
                   Connexion / Inscription
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/cart">
                   Panier
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/wishlist">
                   Favoris
-                </a>
+                </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/shop-with-sidebar">
                   Boutique
-                </a>
+                </Link>
               </li>
             </ul>
           </div>
@@ -309,75 +328,9 @@ const Footer = () => {
                 </Link>
               </li>
               <li>
-                <a className="ease-out duration-200 hover:text-blue" href="#">
+                <Link className="ease-out duration-200 hover:text-blue" href="/contact">
                   Contact
-                </a>
-              </li>
-            </ul>
-          </div>
-
-          <div className="w-full sm:w-auto">
-            <h2 className="mb-7.5 text-custom-1 font-medium text-dark lg:text-right">
-              Télécharger l&apos;application
-            </h2>
-
-            <p className="lg:text-right text-custom-sm mb-4">
-              Économisez avec l&apos;application - Nouveaux utilisateurs uniquement
-            </p>
-
-            <ul className="flex flex-col lg:items-end gap-3">
-              <li>
-                <a
-                  className="inline-flex items-center gap-3 py-[9px] pl-4 pr-7.5 text-white rounded-md bg-dark ease-out duration-200 hover:bg-opacity-95"
-                  href="#"
-                >
-                  <svg
-                    className="fill-current"
-                    width="34"
-                    height="35"
-                    viewBox="0 0 34 35"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M29.5529 12.3412C29.3618 12.4871 25.9887 14.3586 25.9887 18.5198C25.9887 23.3331 30.2809 25.0358 30.4093 25.078C30.3896 25.1818 29.7275 27.41 28.1463 29.6804C26.7364 31.6783 25.264 33.6731 23.024 33.6731C20.7841 33.6731 20.2076 32.3918 17.6217 32.3918C15.1018 32.3918 14.2058 33.7152 12.1569 33.7152C10.1079 33.7152 8.6783 31.8664 7.03456 29.5961C5.13062 26.93 3.59229 22.7882 3.59229 18.8572C3.59229 12.552 7.756 9.20804 11.8538 9.20804C14.0312 9.20804 15.8462 10.6157 17.2133 10.6157C18.5144 10.6157 20.5436 9.12373 23.0207 9.12373C23.9595 9.12373 27.3327 9.20804 29.5529 12.3412ZM21.8447 6.45441C22.8692 5.25759 23.5939 3.59697 23.5939 1.93635C23.5939 1.70607 23.5741 1.47254 23.5313 1.28442C21.8645 1.34605 19.8815 2.37745 18.6857 3.74292C17.7469 4.79379 16.8707 6.45441 16.8707 8.13773C16.8707 8.39076 16.9135 8.64369 16.9333 8.72476C17.0387 8.74426 17.21 8.76694 17.3813 8.76694C18.8768 8.76694 20.7577 7.78094 21.8447 6.45441Z"
-                      fill=""
-                    />
-                  </svg>
-
-                  <div>
-                    <span className="block text-custom-xs">
-                      Télécharger sur
-                    </span>
-                    <p className="font-medium">App Store</p>
-                  </div>
-                </a>
-              </li>
-
-              <li>
-                <a
-                  className="inline-flex items-center gap-3 py-[9px] pl-4 pr-8.5 text-white rounded-md bg-blue ease-out duration-200 hover:bg-opacity-95"
-                  href="#"
-                >
-                  <svg
-                    className="fill-current"
-                    width="34"
-                    height="35"
-                    viewBox="0 0 34 35"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M5.45764 1.03125L19.9718 15.5427L23.7171 11.7973C18.5993 8.69224 11.7448 4.52679 8.66206 2.65395L6.59681 1.40278C6.23175 1.18039 5.84088 1.06062 5.45764 1.03125ZM3.24214 2.76868C3.21276 2.92814 3.1875 3.08837 3.1875 3.26041V31.939C3.1875 32.0593 3.21169 32.1713 3.22848 32.2859L17.9939 17.5205L3.24214 2.76868ZM26.1785 13.2916L21.9496 17.5205L26.1047 21.6756C28.3062 20.3412 29.831 19.4147 30.0003 19.3126C30.7486 18.8552 31.1712 18.1651 31.1586 17.4112C31.1474 16.6713 30.7247 16.0098 30.0057 15.6028C29.8449 15.5104 28.3408 14.6022 26.1785 13.2916ZM19.9718 19.4983L5.50135 33.9688C5.78248 33.9198 6.06327 33.836 6.33182 33.6737C6.70387 33.4471 16.7548 27.3492 23.6433 23.1699L19.9718 19.4983Z"
-                      fill=""
-                    />
-                  </svg>
-
-                  <div>
-                    <span className="block text-custom-xs"> Disponible sur </span>
-                    <p className="font-medium">Google Play</p>
-                  </div>
-                </a>
+                </Link>
               </li>
             </ul>
           </div>

--- a/T-Express-Frontend/src/components/Header/Dropdown.tsx
+++ b/T-Express-Frontend/src/components/Header/Dropdown.tsx
@@ -13,8 +13,10 @@ const Dropdown = ({ menuItem, stickyMenu }) => {
         pathUrl.includes(menuItem.title) && "before:!w-full"
       }`}
     >
-      <a
-        href="#"
+      {/* Ouvre le sous-menu : un bouton, pas un lien vers "#". */}
+      <button
+        type="button"
+        aria-expanded={dropdownToggler}
         className={`hover:text-blue text-custom-sm font-medium text-dark flex items-center gap-1.5 capitalize ${
           stickyMenu ? "xl:py-4" : "xl:py-6"
         } ${pathUrl.includes(menuItem.title) && "!text-blue"}`}
@@ -35,7 +37,7 @@ const Dropdown = ({ menuItem, stickyMenu }) => {
             fill=""
           />
         </svg>
-      </a>
+      </button>
 
       {/* <!-- Dropdown Start --> */}
       <ul


### PR DESCRIPTION
Closes #22

## Ce qui change
**Footer**
- Colonne « Compte » : Mon compte → `/my-account`, Connexion / Inscription → `/signin`, Panier → `/cart`, Favoris → `/wishlist`, Boutique → `/shop-with-sidebar` (même route que le menu). Lien « Contact » de « Liens rapides » → `/contact`.
- Le **téléphone** et l'**e-mail** deviennent des liens `tel:` et `mailto:`, **seulement quand l'admin les a renseignés** dans les paramètres. Le texte d'attente par défaut (« Téléphone à définir par l'administrateur ») ne produit pas de lien invalide.
- **Icônes sociales masquées** tant que leur URL n'est pas configurée : elles pointaient vers `#` par défaut, en state initial comme dans le seeder.
- **Bloc « Télécharger l'application » supprimé** : les badges App Store et Google Play annonçaient une application mobile qui n'existe pas. Le footer passe à 3 colonnes.

**Header**
- Le déclencheur de sous-menu du `Dropdown` était un `<a href="#">`. C'est maintenant un `<button type="button" aria-expanded>`.

Hors périmètre : les icônes de paiement du footer (encore en `href="#"`) relèvent du #6. « Derniers consultés » a déjà été retiré par #8 (#70).

## Tests (Edge + backend local)
- [x] paramètres d'attente : téléphone et e-mail sans lien, aucune icône sociale, aucun badge d'application
- [x] paramètres réels : `tel:+221771188747`, `mailto:contact@t-express.shop`, Facebook et Instagram affichés, Twitter et LinkedIn (restés à `#`) masqués
- [x] les 10 liens de navigation du footer pointent vers des routes existantes
- [x] `tsc --noEmit` et ESLint sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
