### PR TITLE
feat: robots.txt et sitemap.xml (#18)

### DIFF
--- a/T-Express-Frontend/src/app/layout.tsx
+++ b/T-Express-Frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./css/euclid-circular-a-font.css";
 import "./css/style.css";
 import ToastProvider from "@/components/Common/ToastProvider";
+import { SITE_URL } from "@/config/site";
 
 export const metadata: Metadata = {
   // Sans metadataBase, Next.js ne peut pas resoudre les URLs relatives des
@@ -9,13 +10,13 @@ export const metadata: Metadata = {
   // recoivent alors un chemin qu'ils ne peuvent pas recuperer, et l'aperçu de
   // lien echoue silencieusement. Domaine reel du site (voir config/cors.php
   // cote backend) : t-express.shop, pas t-express.sn qui etait utilise ici.
-  metadataBase: new URL("https://t-express.shop"),
+  metadataBase: new URL(SITE_URL),
   title: "T-Express",
   description: "Boutique en ligne T-Express",
   openGraph: {
     title: "T-Express",
     description: "Boutique en ligne T-Express",
-    url: "https://t-express.shop",
+    url: SITE_URL,
     siteName: "T-Express",
     images: [
       {

--- a/T-Express-Frontend/src/app/robots.ts
+++ b/T-Express-Frontend/src/app/robots.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/config/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      // Back-offices et pages propres à un client connecté : sans intérêt
+      // pour la recherche, et à ne pas voir apparaître dans les résultats.
+      disallow: [
+        "/admin",
+        "/super-admin",
+        "/my-account",
+        "/orders",
+        "/cart",
+        "/checkout",
+        "/wishlist",
+        "/payment",
+      ],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/T-Express-Frontend/src/app/sitemap.ts
+++ b/T-Express-Frontend/src/app/sitemap.ts
@@ -1,0 +1,83 @@
+import type { MetadataRoute } from "next";
+import { API_CONFIG } from "@/config/api.config";
+import { SITE_URL } from "@/config/site";
+
+// Les produits changent sans redéploiement : sitemap régénéré au plus toutes
+// les heures. Si l'API est injoignable (par ex. pendant le build Docker), on
+// publie au moins les pages statiques.
+export const revalidate = 3600;
+
+const PAGES_STATIQUES: MetadataRoute.Sitemap = [
+  { url: `${SITE_URL}/`, changeFrequency: "daily", priority: 1 },
+  { url: `${SITE_URL}/shop-with-sidebar`, changeFrequency: "daily", priority: 0.9 },
+  { url: `${SITE_URL}/contact`, changeFrequency: "monthly", priority: 0.5 },
+  { url: `${SITE_URL}/faq`, changeFrequency: "monthly", priority: 0.4 },
+  { url: `${SITE_URL}/refund-policy`, changeFrequency: "yearly", priority: 0.2 },
+  { url: `${SITE_URL}/terms`, changeFrequency: "yearly", priority: 0.2 },
+  { url: `${SITE_URL}/privacy`, changeFrequency: "yearly", priority: 0.2 },
+];
+
+/** Plafond de pages de 100 produits lues, pour borner la génération. */
+const PAGES_PRODUITS_MAX = 50;
+
+type ProduitApi = { id: number; actif?: boolean | number | string; updated_at?: string };
+type CategorieApi = { id: number; updated_at?: string; sous_categories?: CategorieApi[] };
+
+async function appelApi<T>(endpoint: string, body: object): Promise<T | null> {
+  try {
+    const reponse = await fetch(`${API_CONFIG.baseURL}${endpoint}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+    });
+    return reponse.ok ? ((await reponse.json()) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+const date = (valeur?: string) => (valeur ? new Date(valeur) : undefined);
+
+async function entreesProduits(): Promise<MetadataRoute.Sitemap> {
+  const entrees: MetadataRoute.Sitemap = [];
+
+  for (let page = 1, derniere = 1; page <= derniere && page <= PAGES_PRODUITS_MAX; page++) {
+    const reponse = await appelApi<{ data: ProduitApi[]; last_page: number }>(
+      API_CONFIG.endpoints.catalogue.rechercher,
+      { per_page: 100, page }
+    );
+    if (!reponse) break;
+    derniere = reponse.last_page;
+
+    for (const produit of reponse.data) {
+      // `actif` arrive en booléen ou en 0/1 selon le SGBD.
+      if (produit.actif !== undefined && !Number(produit.actif)) continue;
+      entrees.push({
+        url: `${SITE_URL}/shop-details?id=${produit.id}`,
+        lastModified: date(produit.updated_at),
+        changeFrequency: "weekly",
+        priority: 0.7,
+      });
+    }
+  }
+
+  return entrees;
+}
+
+async function entreesCategories(): Promise<MetadataRoute.Sitemap> {
+  const reponse = await appelApi<{ categories: CategorieApi[] }>(API_CONFIG.endpoints.categories.liste, {});
+  // L'API publique ne renvoie déjà que les catégories actives.
+  const toutes = (reponse?.categories ?? []).flatMap((c) => [c, ...(c.sous_categories ?? [])]);
+
+  return toutes.map((categorie) => ({
+    url: `${SITE_URL}/shop-with-sidebar?categorie=${categorie.id}`,
+    lastModified: date(categorie.updated_at),
+    changeFrequency: "weekly",
+    priority: 0.8,
+  }));
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [categories, produits] = await Promise.all([entreesCategories(), entreesProduits()]);
+  return [...PAGES_STATIQUES, ...categories, ...produits];
+}

--- a/T-Express-Frontend/src/config/site.ts
+++ b/T-Express-Frontend/src/config/site.ts
@@ -1,0 +1,5 @@
+/**
+ * Domaine public du site (cf. config/cors.php côté backend) : sert aux URLs
+ * absolues des métadonnées Open Graph, de robots.txt et du sitemap.
+ */
+export const SITE_URL = "https://t-express.shop";


### PR DESCRIPTION
Closes #18

## Ce qui change
Conventions App Router (fichiers servis par Next.js, pas de fichier statique à maintenir) :

**`/robots.txt`** (`src/app/robots.ts`)
```
User-Agent: *
Allow: /
Disallow: /admin
Disallow: /super-admin
Disallow: /my-account
Disallow: /orders
Disallow: /cart
Disallow: /checkout
Disallow: /wishlist
Disallow: /payment        (couvre aussi /payment-success)

Sitemap: https://t-express.shop/sitemap.xml
```
En plus de `/admin` et `/super-admin` demandés, le fichier bloque les pages propres à un client connecté : sans intérêt pour la recherche.

**`/sitemap.xml`** (`src/app/sitemap.ts`)
- pages statiques : accueil, boutique, contact, FAQ et pages légales (#14) ;
- **catégories et sous-catégories actives** → `/shop-with-sidebar?categorie=<id>` ;
- **produits actifs** → `/shop-details?id=<id>`, avec `lastModified` = `updated_at` ;
- données lues depuis l'API publique (`catalogue/rechercher` paginé par 100, plafonné à 50 pages ; `categories/liste`) ;
- **régénéré au plus toutes les heures** (`revalidate = 3600`) : les produits changent sans redéploiement ;
- **API injoignable (par exemple pendant le build Docker) : le sitemap publie quand même les pages statiques** au lieu d'échouer.

Le domaine est centralisé dans `src/config/site.ts`, réutilisé par `layout.tsx` (`metadataBase`, Open Graph).

## Tests (frontend en dev + backend local)
- [x] `/robots.txt` : contenu ci-dessus
- [x] `/sitemap.xml` : 200, `application/xml`, 7 pages statiques + 1 catégorie + 4 produits
- [x] produit passé inactif → absent du sitemap
- [x] backend arrêté → 200 avec les 7 pages statiques
- [x] `tsc --noEmit` et ESLint sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
