### PR TITLE
feat: vues mobiles en cartes pour le panier et les tableaux admin (#30)

### DIFF
--- a/T-Express-Frontend/src/app/admin/categories/page.tsx
+++ b/T-Express-Frontend/src/app/admin/categories/page.tsx
@@ -149,6 +149,69 @@ export default function AdminCategories() {
     }
   };
 
+  // Éléments partagés par le tableau (desktop) et les cartes (mobile).
+  const imageCategorie = (cat: Categorie) =>
+    cat.image ? (
+      <img
+        src={resolveBackendImageUrl(cat.image, '/images/categories/default.png')}
+        alt={cat.nom}
+        className="w-16 h-16 object-cover rounded-lg"
+        onError={(e) => {
+          e.currentTarget.src = '/images/categories/default.png';
+        }}
+      />
+    ) : (
+      <div className="w-16 h-16 bg-gray-2 rounded-lg flex items-center justify-center">
+        <svg className="w-8 h-8 text-gray-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+        </svg>
+      </div>
+    );
+
+  const nombreProduits = (cat: Categorie) => (
+    <span className="px-3 py-1 bg-blue-light-5 text-blue rounded-full text-sm font-medium">
+      {cat.produits_count || 0} produits
+    </span>
+  );
+
+  const statutCategorie = (cat: Categorie) => (
+    <span className={`px-3 py-1 rounded-full text-xs font-semibold ${
+      cat.actif
+        ? 'bg-green-light-6 text-green-dark'
+        : 'bg-gray-3 text-dark-4'
+    }`}>
+      {cat.actif ? 'Active' : 'Inactive'}
+    </span>
+  );
+
+  const actionsCategorie = (cat: Categorie) => (
+    <div className="flex items-center justify-end gap-2">
+      <button
+        onClick={() => openModal(cat)}
+        className="p-2 text-blue hover:bg-blue-light-5 rounded-lg transition-colors"
+        aria-label={`Modifier ${cat.nom}`}
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
+      </button>
+      <button
+        onClick={() => handleDelete(cat.id)}
+        disabled={deleteId === cat.id}
+        className="p-2 text-red hover:bg-red-light-6 rounded-lg transition-colors disabled:opacity-50"
+        aria-label={`Supprimer ${cat.nom}`}
+      >
+        {deleteId === cat.id ? (
+          <div className="w-5 h-5 border-2 border-red border-t-transparent rounded-full animate-spin"></div>
+        ) : (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+
   return (
     <div className="p-6 lg:p-8">
       <div className="mb-8">
@@ -182,7 +245,34 @@ export default function AdminCategories() {
             </button>
           </div>
         ) : (
-          <div className="overflow-x-auto">
+          <>
+          {/* Cartes sur mobile : le tableau (6 colonnes) débordait de l'écran. */}
+          <ul className="md:hidden divide-y divide-gray-3">
+            {categories.length === 0 ? (
+              <li className="px-4 py-12 text-center text-dark-4">Aucune catégorie trouvée</li>
+            ) : (
+              categories.map((cat) => (
+                <li key={cat.id} className="p-4 flex gap-4">
+                  <div className="flex-shrink-0">{imageCategorie(cat)}</div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="font-semibold text-dark break-words">{cat.nom}</p>
+                        <p className="text-xs text-dark-4 font-mono break-all">{cat.slug}</p>
+                      </div>
+                      {actionsCategorie(cat)}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 mt-2">
+                      {nombreProduits(cat)}
+                      {statutCategorie(cat)}
+                    </div>
+                  </div>
+                </li>
+              ))
+            )}
+          </ul>
+
+          <div className="hidden md:block overflow-x-auto">
             <table className="w-full">
               <thead className="bg-gray-1 border-b border-gray-3">
                 <tr>
@@ -204,75 +294,21 @@ export default function AdminCategories() {
                 ) : (
                   categories.map((cat) => (
                     <tr key={cat.id} className="hover:bg-gray-1 transition-colors">
+                      <td className="px-6 py-4">{imageCategorie(cat)}</td>
                       <td className="px-6 py-4">
-                        {cat.image ? (
-                          <img
-                            src={resolveBackendImageUrl(cat.image, '/images/categories/default.png')}
-                            alt={cat.nom}
-                            className="w-16 h-16 object-cover rounded-lg"
-                            onError={(e) => {
-                              e.currentTarget.src = '/images/categories/default.png';
-                            }}
-                          />
-                        ) : (
-                          <div className="w-16 h-16 bg-gray-2 rounded-lg flex items-center justify-center">
-                            <svg className="w-8 h-8 text-gray-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-                            </svg>
-                          </div>
-                        )}
-                      </td>
-                      <td className="px-6 py-4">
-                        <div>
-                          <p className="font-semibold text-dark">{cat.nom}</p>
-                        </div>
+                        <p className="font-semibold text-dark">{cat.nom}</p>
                       </td>
                       <td className="px-6 py-4 text-dark-4 font-mono text-sm">{cat.slug}</td>
-                      <td className="px-6 py-4">
-                        <span className="px-3 py-1 bg-blue-light-5 text-blue rounded-full text-sm font-medium">
-                          {cat.produits_count || 0} produits
-                        </span>
-                      </td>
-                      <td className="px-6 py-4">
-                        <span className={`px-3 py-1 rounded-full text-xs font-semibold ${
-                          cat.actif 
-                            ? 'bg-green-light-6 text-green-dark' 
-                            : 'bg-gray-3 text-dark-4'
-                        }`}>
-                          {cat.actif ? 'Active' : 'Inactive'}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 text-right">
-                        <div className="flex items-center justify-end gap-2">
-                          <button
-                            onClick={() => openModal(cat)}
-                            className="p-2 text-blue hover:bg-blue-light-5 rounded-lg transition-colors"
-                          >
-                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                            </svg>
-                          </button>
-                          <button
-                            onClick={() => handleDelete(cat.id)}
-                            disabled={deleteId === cat.id}
-                            className="p-2 text-red hover:bg-red-light-6 rounded-lg transition-colors disabled:opacity-50"
-                          >
-                            {deleteId === cat.id ? (
-                              <div className="w-5 h-5 border-2 border-red border-t-transparent rounded-full animate-spin"></div>
-                            ) : (
-                              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                              </svg>
-                            )}
-                          </button>
-                        </div>
-                      </td>
+                      <td className="px-6 py-4">{nombreProduits(cat)}</td>
+                      <td className="px-6 py-4">{statutCategorie(cat)}</td>
+                      <td className="px-6 py-4 text-right">{actionsCategorie(cat)}</td>
                     </tr>
                   ))
                 )}
               </tbody>
             </table>
           </div>
+          </>
         )}
       </div>
 

--- a/T-Express-Frontend/src/app/admin/commandes/page.tsx
+++ b/T-Express-Frontend/src/app/admin/commandes/page.tsx
@@ -7,34 +7,46 @@ import Link from "next/link";
 import toast from "react-hot-toast";
 import AdminErrorState from "@/components/Admin/AdminErrorState";
 
+// Couleurs du thème Tailwind du projet (palette redéfinie : bg-yellow-100,
+// bg-purple-100... n'y existent pas et laissaient les badges sans couleur).
+const COULEUR = {
+  attente: "bg-yellow-light-2 text-yellow-dark-2",
+  info: "bg-blue-light-5 text-blue-dark",
+  encours: "bg-orange/10 text-orange-dark",
+  expedie: "bg-teal/10 text-teal-dark",
+  succes: "bg-green-light-6 text-green-dark",
+  echec: "bg-red-light-6 text-red-dark",
+  neutre: "bg-gray-2 text-dark-4",
+};
+
 // Statuts de commande (affichage seulement, pas modifiable directement)
 const STATUTS_COMMANDE: Record<string, { label: string; color: string }> = {
-  "En attente": { label: "En attente", color: "bg-yellow-100 text-yellow-800" },
-  "Validée": { label: "Validée", color: "bg-blue-100 text-blue-800" },
-  "Préparation": { label: "En préparation", color: "bg-orange-100 text-orange-800" },
-  "Expédiée": { label: "Expédiée", color: "bg-purple-100 text-purple-800" },
-  "Livrée": { label: "Livrée", color: "bg-green-100 text-green-800" },
-  "Annulée": { label: "Annulée", color: "bg-red-100 text-red-800" },
+  "En attente": { label: "En attente", color: COULEUR.attente },
+  "Validée": { label: "Validée", color: COULEUR.info },
+  "Préparation": { label: "En préparation", color: COULEUR.encours },
+  "Expédiée": { label: "Expédiée", color: COULEUR.expedie },
+  "Livrée": { label: "Livrée", color: COULEUR.succes },
+  "Annulée": { label: "Annulée", color: COULEUR.echec },
 };
 
 // Valeurs exactes de l'ENUM dans la table paiements (modifiable par l'admin)
 const STATUTS_PAIEMENT_OPTIONS = [
-  { value: "en_attente", label: "En attente", color: "bg-yellow-100 text-yellow-800" },
-  { value: "validé", label: "Validé", color: "bg-green-100 text-green-800" },
-  { value: "Complété", label: "Complété", color: "bg-green-100 text-green-800" },
-  { value: "Accepté", label: "Accepté", color: "bg-green-100 text-green-800" },
-  { value: "échoué", label: "Échoué", color: "bg-red-100 text-red-800" },
-  { value: "Refusé", label: "Refusé", color: "bg-red-100 text-red-800" },
+  { value: "en_attente", label: "En attente", color: COULEUR.attente },
+  { value: "validé", label: "Validé", color: COULEUR.succes },
+  { value: "Complété", label: "Complété", color: COULEUR.succes },
+  { value: "Accepté", label: "Accepté", color: COULEUR.succes },
+  { value: "échoué", label: "Échoué", color: COULEUR.echec },
+  { value: "Refusé", label: "Refusé", color: COULEUR.echec },
 ];
 
 const STATUTS_PAIEMENT: Record<string, { label: string; color: string }> = {
-  "en_attente": { label: "En attente", color: "bg-yellow-100 text-yellow-800" },
-  "En attente": { label: "En attente", color: "bg-yellow-100 text-yellow-800" },
-  "validé": { label: "Validé", color: "bg-green-100 text-green-800" },
-  "Complété": { label: "Complété", color: "bg-green-100 text-green-800" },
-  "Accepté": { label: "Accepté", color: "bg-green-100 text-green-800" },
-  "échoué": { label: "Échoué", color: "bg-red-100 text-red-800" },
-  "Refusé": { label: "Refusé", color: "bg-red-100 text-red-800" },
+  "en_attente": { label: "En attente", color: COULEUR.attente },
+  "En attente": { label: "En attente", color: COULEUR.attente },
+  "validé": { label: "Validé", color: COULEUR.succes },
+  "Complété": { label: "Complété", color: COULEUR.succes },
+  "Accepté": { label: "Accepté", color: COULEUR.succes },
+  "échoué": { label: "Échoué", color: COULEUR.echec },
+  "Refusé": { label: "Refusé", color: COULEUR.echec },
 };
 
 export default function AdminCommandes() {
@@ -102,26 +114,98 @@ export default function AdminCommandes() {
 
   // Obtenir le style du statut de commande
   const getStatutCommandeStyle = (statut: string) => {
-    return STATUTS_COMMANDE[statut]?.color || "bg-gray-100 text-gray-800";
+    return STATUTS_COMMANDE[statut]?.color || COULEUR.neutre;
   };
 
   // Obtenir le style du statut de paiement
   const getStatutPaiementStyle = (statut?: string) => {
-    if (!statut) return { label: "N/A", color: "bg-gray-100 text-gray-800" };
-    return STATUTS_PAIEMENT[statut] || { label: statut, color: "bg-gray-100 text-gray-800" };
+    if (!statut) return { label: "N/A", color: COULEUR.neutre };
+    return STATUTS_PAIEMENT[statut] || { label: statut, color: COULEUR.neutre };
   };
+
+  const nomClient = (cmd: Commande) =>
+    cmd.client ? `${cmd.client.prenom} ${cmd.client.nom}` : `Client #${cmd.client_id}`;
+
+  // Éléments partagés par le tableau (desktop) et les cartes (mobile).
+  const selectPaiement = (cmd: Commande) => (
+    <>
+      <select
+        value={cmd.paiement?.statut || "en_attente"}
+        onChange={(e) => handleStatusChange(cmd.id, e.target.value)}
+        disabled={updatingStatus === cmd.id || !cmd.paiement}
+        aria-label={`Statut du paiement de la commande #${cmd.id}`}
+        className={`text-xs font-medium rounded-lg px-2 py-1.5 border cursor-pointer ${getStatutPaiementStyle(cmd.paiement?.statut).color}`}
+      >
+        {STATUTS_PAIEMENT_OPTIONS.map((s) => (
+          <option key={s.value} value={s.value}>
+            {s.label}
+          </option>
+        ))}
+      </select>
+      {updatingStatus === cmd.id && <span className="ml-2 text-xs text-dark-4">...</span>}
+    </>
+  );
+
+  const badgeCommande = (cmd: Commande) => {
+    const style = STATUTS_COMMANDE[cmd.statut] || { label: cmd.statut, color: COULEUR.neutre };
+    return (
+      <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${style.color}`}>
+        {style.label}
+      </span>
+    );
+  };
+
+  const actions = (cmd: Commande, disposition: string) => (
+    <div className={disposition}>
+      <button className="text-blue hover:underline text-sm text-left" onClick={() => handleShowDetail(cmd.id)}>
+        Voir détails
+      </button>
+      <Link href={`/admin/livraisons?commande=${cmd.id}`} className="text-teal-dark hover:underline text-sm">
+        Gérer livraison
+      </Link>
+    </div>
+  );
 
   return (
     <div>
       <h1 className="text-2xl font-bold mb-6">Gestion des commandes</h1>
-      
-      <div className="bg-white rounded shadow p-6">
+
+      <div className="bg-white rounded shadow p-4 sm:p-6">
         {loading && !commandes.length ? (
           <div className="text-center py-8">Chargement...</div>
         ) : error ? (
           <AdminErrorState message={error} onRetry={fetchCommandes} />
         ) : (
-          <div className="overflow-x-auto">
+          <>
+          {/* Cartes sur mobile : le tableau (7 colonnes) débordait de l'écran. */}
+          <ul className="md:hidden divide-y divide-gray-3">
+            {commandes.length === 0 ? (
+              <li className="text-center py-8 text-dark-4">Aucune commande trouvée.</li>
+            ) : (
+              commandes.map((cmd) => (
+                <li key={cmd.id} className="py-4 first:pt-0 last:pb-0">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="font-semibold text-dark">#{cmd.id}</p>
+                      <p className="text-sm text-dark truncate">{nomClient(cmd)}</p>
+                      <p className="text-xs text-dark-4">{LOCALE_CONFIG.formatDate(cmd.created_at)}</p>
+                    </div>
+                    <p className="font-semibold text-dark whitespace-nowrap">
+                      {LOCALE_CONFIG.formatPrice(cmd.montant_total)}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 mt-3">
+                    {badgeCommande(cmd)}
+                    <span className="text-xs text-dark-4">Paiement :</span>
+                    {selectPaiement(cmd)}
+                  </div>
+                  {actions(cmd, "flex gap-5 mt-3")}
+                </li>
+              ))
+            )}
+          </ul>
+
+          <div className="hidden md:block overflow-x-auto">
             <table className="w-full text-left text-sm">
               <thead className="bg-gray-50">
                 <tr>
@@ -142,71 +226,29 @@ export default function AdminCommandes() {
                     </td>
                   </tr>
                 ) : (
-                  commandes.map((cmd) => {
-                    const paiementStyle = getStatutPaiementStyle(cmd.paiement?.statut);
-                    const commandeStyle = STATUTS_COMMANDE[cmd.statut] || { label: cmd.statut, color: "bg-gray-100 text-gray-800" };
-                    return (
-                      <tr key={cmd.id} className="hover:bg-gray-50">
+                  commandes.map((cmd) => (
+                      <tr key={cmd.id} className="hover:bg-gray-1">
                         <td className="py-3 px-3 font-medium">#{cmd.id}</td>
-                        <td className="py-3 px-3">
-                          {cmd.client ? `${cmd.client.prenom} ${cmd.client.nom}` : `Client #${cmd.client_id}`}
-                        </td>
+                        <td className="py-3 px-3">{nomClient(cmd)}</td>
                         <td className="py-3 px-3">{LOCALE_CONFIG.formatDate(cmd.created_at)}</td>
                         <td className="py-3 px-3 font-medium">{LOCALE_CONFIG.formatPrice(cmd.montant_total)}</td>
-                        <td className="py-3 px-3">
-                          {/* Dropdown pour changer le statut de paiement */}
-                          <select
-                            value={cmd.paiement?.statut || "en_attente"}
-                            onChange={(e) => handleStatusChange(cmd.id, e.target.value)}
-                            disabled={updatingStatus === cmd.id || !cmd.paiement}
-                            className={`text-xs font-medium rounded-lg px-2 py-1.5 border cursor-pointer ${paiementStyle.color}`}
-                          >
-                            {STATUTS_PAIEMENT_OPTIONS.map((s) => (
-                              <option key={s.value} value={s.value}>
-                                {s.label}
-                              </option>
-                            ))}
-                          </select>
-                          {updatingStatus === cmd.id && (
-                            <span className="ml-2 text-xs text-gray-500">...</span>
-                          )}
-                        </td>
-                        <td className="py-3 px-3">
-                          {/* Statut de commande en lecture seule */}
-                          <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${commandeStyle.color}`}>
-                            {commandeStyle.label}
-                          </span>
-                        </td>
-                        <td className="py-3 px-3">
-  <div className="flex flex-col gap-1">
-    <button
-      className="text-blue-600 hover:underline text-sm text-left"
-      onClick={() => handleShowDetail(cmd.id)}
-    >
-      Voir détails
-    </button>
-    
-     <Link
-  href={`/admin/livraisons?commande=${cmd.id}`}
-  className="text-purple-600 hover:underline text-sm"
->
-  Gérer livraison
-</Link>
-  </div>
-</td>
+                        <td className="py-3 px-3">{selectPaiement(cmd)}</td>
+                        {/* Statut de commande en lecture seule */}
+                        <td className="py-3 px-3">{badgeCommande(cmd)}</td>
+                        <td className="py-3 px-3">{actions(cmd, "flex flex-col gap-1")}</td>
                       </tr>
-                    );
-                  })
+                  ))
                 )}
               </tbody>
             </table>
           </div>
+          </>
         )}
       </div>
 
       {/* Modal détail commande */}
       {showDetail && (
-        <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-dark/40 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
             <div className="sticky top-0 bg-white border-b px-6 py-4 flex justify-between items-center">
               <h2 className="text-xl font-semibold">Commande #{showDetail.id}</h2>

--- a/T-Express-Frontend/src/app/admin/livraisons/page.tsx
+++ b/T-Express-Frontend/src/app/admin/livraisons/page.tsx
@@ -100,6 +100,35 @@ const [autoOpenHandled, setAutoOpenHandled] = useState(false);
     }
   };
 
+  // Éléments partagés par le tableau (desktop) et les cartes (mobile).
+  const nomClient = (l: Livraison) =>
+    l.commande?.client ? `${l.commande.client.prenom} ${l.commande.client.nom}` : "-";
+
+  const badgeStatut = (l: Livraison) => {
+    const statutColor = STATUT_COLORS[l.statut] || { bg: "bg-gray-3", text: "text-dark-4" };
+    return (
+      <span className={`px-3 py-1 rounded-full text-xs font-semibold ${statutColor.bg} ${statutColor.text}`}>
+        {l.statut}
+      </span>
+    );
+  };
+
+  const boutonModifier = (l: Livraison) => (
+    <button
+      onClick={() => openEditModal(l)}
+      className="p-2 text-blue hover:bg-blue-light-5 rounded-lg transition-colors"
+      title="Modifier"
+      aria-label={`Modifier la livraison ${l.id}`}
+    >
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+      </svg>
+    </button>
+  );
+
+  const datePrevue = (l: Livraison) =>
+    l.date_livraison_estimee ? LOCALE_CONFIG.formatDate(l.date_livraison_estimee) : "-";
+
   return (
     <div className="p-6 lg:p-8">
       <div className="mb-8">
@@ -150,7 +179,33 @@ const [autoOpenHandled, setAutoOpenHandled] = useState(false);
           </div>
         ) : (
           <>
-            <div className="overflow-x-auto">
+            {/* Cartes sur mobile : le tableau (7 colonnes) débordait de l'écran. */}
+            <ul className="md:hidden divide-y divide-gray-3">
+              {livraisons.length === 0 ? (
+                <li className="px-4 py-12 text-center text-dark-4">Aucune livraison trouvée</li>
+              ) : (
+                livraisons.map((l) => (
+                  <li key={l.id} className="p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-semibold text-dark">
+                          Livraison {l.id} · Commande #{l.commande_id}
+                        </p>
+                        <p className="text-sm text-dark truncate">{nomClient(l)}</p>
+                      </div>
+                      {boutonModifier(l)}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mt-2 text-sm text-dark-4">
+                      {badgeStatut(l)}
+                      <span>Suivi : {l.numero_suivi || "-"}</span>
+                      <span>Prévue : {datePrevue(l)}</span>
+                    </div>
+                  </li>
+                ))
+              )}
+            </ul>
+
+            <div className="hidden md:block overflow-x-auto">
               <table className="w-full">
                 <thead className="bg-gray-1 border-b border-gray-3">
                   <tr>
@@ -171,44 +226,17 @@ const [autoOpenHandled, setAutoOpenHandled] = useState(false);
                       </td>
                     </tr>
                   ) : (
-                    livraisons.map((l) => {
-                      const statutColor = STATUT_COLORS[l.statut] || { bg: "bg-gray-3", text: "text-dark-4" };
-                      return (
+                    livraisons.map((l) => (
                         <tr key={l.id} className="hover:bg-gray-1 transition-colors">
                           <td className="px-6 py-4 font-semibold text-dark">{l.id}</td>
-                          <td className="px-6 py-4 text-dark">
-                            {`#${l.commande_id}`}
-                          </td>
-                          <td className="px-6 py-4 text-dark">
-                            {l.commande?.client
-                              ? `${l.commande.client.prenom} ${l.commande.client.nom}`
-                              : "-"}
-                          </td>
-                          <td className="px-6 py-4 text-dark-4">
-                            {l.numero_suivi || "-"}
-                          </td>
-                          <td className="px-6 py-4">
-                            <span className={`px-3 py-1 rounded-full text-xs font-semibold ${statutColor.bg} ${statutColor.text}`}>
-                              {l.statut}
-                            </span>
-                          </td>
-                          <td className="px-6 py-4 text-dark-4 text-sm">
-                            {l.date_livraison_estimee ? LOCALE_CONFIG.formatDate(l.date_livraison_estimee) : "-"}
-                          </td>
-                          <td className="px-6 py-4 text-right">
-                            <button
-                              onClick={() => openEditModal(l)}
-                              className="p-2 text-blue hover:bg-blue-light-5 rounded-lg transition-colors"
-                              title="Modifier"
-                            >
-                              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                              </svg>
-                            </button>
-                          </td>
+                          <td className="px-6 py-4 text-dark">{`#${l.commande_id}`}</td>
+                          <td className="px-6 py-4 text-dark">{nomClient(l)}</td>
+                          <td className="px-6 py-4 text-dark-4">{l.numero_suivi || "-"}</td>
+                          <td className="px-6 py-4">{badgeStatut(l)}</td>
+                          <td className="px-6 py-4 text-dark-4 text-sm">{datePrevue(l)}</td>
+                          <td className="px-6 py-4 text-right">{boutonModifier(l)}</td>
                         </tr>
-                      );
-                    })
+                    ))
                   )}
                 </tbody>
               </table>

--- a/T-Express-Frontend/src/app/admin/produits/page.tsx
+++ b/T-Express-Frontend/src/app/admin/produits/page.tsx
@@ -243,6 +243,85 @@ export default function AdminProduits() {
     }
   };
 
+  // Éléments partagés par le tableau (desktop) et les cartes (mobile).
+  const imageProduit = (prod: Produit) =>
+    prod.image_principale ? (
+      <img
+        src={resolveBackendImageUrl(prod.image_principale, '/images/products/default.png')}
+        alt={prod.nom}
+        className="w-16 h-16 object-cover rounded-lg"
+        onError={(e) => {
+          e.currentTarget.src = '/images/products/default.png';
+        }}
+      />
+    ) : (
+      <div className="w-16 h-16 bg-gray-2 rounded-lg flex items-center justify-center">
+        <svg className="w-8 h-8 text-gray-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+      </div>
+    );
+
+  const prixProduit = (prod: Produit) => (
+    <div>
+      <p className="font-bold text-dark">{LOCALE_CONFIG.formatPrice(prod.prix)}</p>
+      {prod.prix_promo && (
+        <p className="text-sm text-green line-through">{LOCALE_CONFIG.formatPrice(prod.prix_promo)}</p>
+      )}
+    </div>
+  );
+
+  const stockProduit = (prod: Produit) => (
+    <div className="flex items-center gap-2">
+      <span className={`font-semibold ${(prod.stock?.quantite ?? 0) <= 10 ? 'text-red' : 'text-green'}`}>
+        {prod.stock?.quantite ?? 0}
+      </span>
+      {(prod.stock?.quantite ?? 0) <= 10 && (
+        <span className="px-2 py-0.5 bg-red-light-6 text-red-dark text-xs rounded-full">Faible</span>
+      )}
+    </div>
+  );
+
+  const statutProduit = (prod: Produit) => (
+    <span className={`px-3 py-1 rounded-full text-xs font-semibold ${
+      prod.actif
+        ? 'bg-green-light-6 text-green-dark'
+        : 'bg-gray-3 text-dark-4'
+    }`}>
+      {prod.actif ? 'Actif' : 'Inactif'}
+    </span>
+  );
+
+  const actionsProduit = (prod: Produit) => (
+    <div className="flex items-center justify-end gap-2">
+      <button
+        onClick={() => openModal(prod)}
+        className="p-2 text-blue hover:bg-blue-light-5 rounded-lg transition-colors"
+        title="Modifier"
+        aria-label={`Modifier ${prod.nom}`}
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
+      </button>
+      <button
+        onClick={() => handleDelete(prod.id)}
+        disabled={deleteLoading && deleteId === prod.id}
+        className="p-2 text-red hover:bg-red-light-6 rounded-lg transition-colors disabled:opacity-50"
+        title="Supprimer"
+        aria-label={`Supprimer ${prod.nom}`}
+      >
+        {deleteLoading && deleteId === prod.id ? (
+          <div className="w-5 h-5 border-2 border-red border-t-transparent rounded-full animate-spin"></div>
+        ) : (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+
   return (
     <div className="p-6 lg:p-8">
       {/* Header */}
@@ -276,7 +355,44 @@ export default function AdminProduits() {
           <AdminErrorState message={error} onRetry={fetchData} />
         ) : (
           <>
-            <div className="overflow-x-auto">
+            {/* Cartes sur mobile : le tableau (7 colonnes) débordait de l'écran. */}
+            <ul className="md:hidden divide-y divide-gray-3">
+              {produits.length === 0 ? (
+                <li className="px-4 py-12 text-center">
+                  <p className="text-dark-4">Aucun produit trouvé</p>
+                  <button onClick={() => openModal()} className="mt-3 text-blue hover:text-blue-dark font-medium">
+                    Créer votre premier produit
+                  </button>
+                </li>
+              ) : (
+                produits.map((prod) => (
+                  <li key={prod.id} className="p-4">
+                    <div className="flex gap-4">
+                      <div className="flex-shrink-0">{imageProduit(prod)}</div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0">
+                            <p className="font-semibold text-dark break-words">{prod.nom}</p>
+                            {prod.reference && <p className="text-xs text-dark-4 break-all">Ref: {prod.reference}</p>}
+                          </div>
+                          {actionsProduit(prod)}
+                        </div>
+                        <div className="mt-2">{prixProduit(prod)}</div>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mt-3 text-sm">
+                      <span className="px-3 py-1 bg-blue-light-5 text-blue rounded-full text-xs font-medium">
+                        {prod.categorie?.nom || "-"}
+                      </span>
+                      <span className="flex items-center gap-1.5 text-dark-4">Stock : {stockProduit(prod)}</span>
+                      {statutProduit(prod)}
+                    </div>
+                  </li>
+                ))
+              )}
+            </ul>
+
+            <div className="hidden md:block overflow-x-auto">
               <table className="w-full">
                 <thead className="bg-gray-1 border-b border-gray-3">
                   <tr>
@@ -310,24 +426,7 @@ export default function AdminProduits() {
                   ) : (
                     produits.map((prod) => (
                       <tr key={prod.id} className="hover:bg-gray-1 transition-colors">
-                        <td className="px-6 py-4">
-                          {prod.image_principale ? (
-                            <img
-                              src={resolveBackendImageUrl(prod.image_principale, '/images/products/default.png')}
-                              alt={prod.nom}
-                              className="w-16 h-16 object-cover rounded-lg"
-                              onError={(e) => {
-                                e.currentTarget.src = '/images/products/default.png';
-                              }}
-                            />
-                          ) : (
-                            <div className="w-16 h-16 bg-gray-2 rounded-lg flex items-center justify-center">
-                              <svg className="w-8 h-8 text-gray-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                              </svg>
-                            </div>
-                          )}
-                        </td>
+                        <td className="px-6 py-4">{imageProduit(prod)}</td>
                         <td className="px-6 py-4">
                           <div>
                             <p className="font-semibold text-dark">{prod.nom}</p>
@@ -341,60 +440,10 @@ export default function AdminProduits() {
                             {prod.categorie?.nom || "-"}
                           </span>
                         </td>
-                        <td className="px-6 py-4">
-                          <div>
-                            <p className="font-bold text-dark">{LOCALE_CONFIG.formatPrice(prod.prix)}</p>
-                            {prod.prix_promo && (
-                              <p className="text-sm text-green line-through">{LOCALE_CONFIG.formatPrice(prod.prix_promo)}</p>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-6 py-4">
-                          <div className="flex items-center gap-2">
-                            <span className={`font-semibold ${(prod.stock?.quantite ?? 0) <= 10 ? 'text-red' : 'text-green'}`}>
-                              {prod.stock?.quantite ?? 0}
-                            </span>
-                            {(prod.stock?.quantite ?? 0) <= 10 && (
-                              <span className="px-2 py-0.5 bg-red-light-6 text-red-dark text-xs rounded-full">Faible</span>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-6 py-4">
-                          <span className={`px-3 py-1 rounded-full text-xs font-semibold ${
-                            prod.actif 
-                              ? 'bg-green-light-6 text-green-dark' 
-                              : 'bg-gray-3 text-dark-4'
-                          }`}>
-                            {prod.actif ? 'Actif' : 'Inactif'}
-                          </span>
-                        </td>
-                        <td className="px-6 py-4 text-right">
-                          <div className="flex items-center justify-end gap-2">
-                            <button
-                              onClick={() => openModal(prod)}
-                              className="p-2 text-blue hover:bg-blue-light-5 rounded-lg transition-colors"
-                              title="Modifier"
-                            >
-                              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                              </svg>
-                            </button>
-                            <button
-                              onClick={() => handleDelete(prod.id)}
-                              disabled={deleteLoading && deleteId === prod.id}
-                              className="p-2 text-red hover:bg-red-light-6 rounded-lg transition-colors disabled:opacity-50"
-                              title="Supprimer"
-                            >
-                              {deleteLoading && deleteId === prod.id ? (
-                                <div className="w-5 h-5 border-2 border-red border-t-transparent rounded-full animate-spin"></div>
-                              ) : (
-                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                </svg>
-                              )}
-                            </button>
-                          </div>
-                        </td>
+                        <td className="px-6 py-4">{prixProduit(prod)}</td>
+                        <td className="px-6 py-4">{stockProduit(prod)}</td>
+                        <td className="px-6 py-4">{statutProduit(prod)}</td>
+                        <td className="px-6 py-4 text-right">{actionsProduit(prod)}</td>
                       </tr>
                     ))
                   )}

--- a/T-Express-Frontend/src/components/Cart/SingleItemNew.tsx
+++ b/T-Express-Frontend/src/components/Cart/SingleItemNew.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { usePanier } from "@/hooks/usePanier";
+import Link from "next/link";
 import Image from "next/image";
+import { usePanierContext } from "@/context/PanierContext";
 import type { LignePanier } from "@/types/api.types";
 import { API_CONFIG } from "@/config/api.config";
 
@@ -9,7 +10,10 @@ interface SingleItemProps {
 }
 
 const SingleItemNew = ({ item }: SingleItemProps) => {
-  const { mettreAJour, supprimer, updateLoading, deleteLoading } = usePanier();
+  // Contexte partagé, pas usePanier() : une instance privée par ligne
+  // modifiait le backend sans rafraîchir la quantité affichée, le total ni
+  // le compteur du header, et rechargeait tout le panier pour chaque ligne.
+  const { mettreAJour, supprimer, updateLoading, deleteLoading } = usePanierContext();
 
   const handleRemoveFromCart = async () => {
     if (window.confirm("Voulez-vous vraiment supprimer ce produit du panier ?")) {
@@ -93,130 +97,114 @@ const SingleItemNew = ({ item }: SingleItemProps) => {
   const unitPrice = item.produit.prix_promo || item.produit.prix;
   const subtotal = unitPrice * item.quantite;
 
-  return (
-    <div className="flex items-center border-t border-gray-3 py-5 px-7.5">
-      <div className="min-w-[400px]">
-        <div className="flex items-center justify-between gap-5">
-          <div className="w-full flex items-center gap-5.5">
-            <div className="flex items-center justify-center rounded-[5px] bg-gray-2 max-w-[80px] w-full h-17.5 overflow-hidden">
-              <Image 
-                width={80} 
-                height={70} 
-                src={productImage} 
-                alt={item.produit.nom}
-                className="object-cover w-full h-full"
-                unoptimized={productImage.includes(API_CONFIG.baseURL)}
-              />
-            </div>
+  // Contrôles partagés par la carte (mobile/tablette) et la ligne (desktop).
+  const image = (
+    <Image
+      width={80}
+      height={70}
+      src={productImage}
+      alt={item.produit.nom}
+      className="object-cover w-full h-full"
+      unoptimized={productImage.includes(API_CONFIG.baseURL)}
+    />
+  );
 
-            <div>
-              <h3 className="text-dark ease-out duration-200 hover:text-blue">
-                <a href={`/shop-details?id=${item.produit.id}`}> {item.produit.nom} </a>
-              </h3>
-            </div>
+  const nom = (
+    <Link href={`/shop-details?id=${item.produit.id}`} className="text-dark ease-out duration-200 hover:text-blue">
+      {item.produit.nom}
+    </Link>
+  );
+
+  const quantite = (
+    <div className="w-max flex items-center rounded-md border border-gray-3">
+      <button
+        onClick={handleDecreaseQuantity}
+        disabled={updateLoading || item.quantite <= 1}
+        aria-label="Diminuer la quantité"
+        className="flex items-center justify-center w-11.5 h-11.5 ease-out duration-200 hover:text-blue disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <svg className="fill-current" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M3.33301 10.0001C3.33301 9.53984 3.7061 9.16675 4.16634 9.16675H15.833C16.2932 9.16675 16.6663 9.53984 16.6663 10.0001C16.6663 10.4603 16.2932 10.8334 15.833 10.8334H4.16634C3.7061 10.8334 3.33301 10.4603 3.33301 10.0001Z" fill="" />
+        </svg>
+      </button>
+
+      <span className="flex items-center justify-center w-12 xl:w-16 h-11.5 border-x border-gray-4" aria-live="polite">
+        {updateLoading ? "..." : item.quantite}
+      </span>
+
+      <button
+        onClick={handleIncreaseQuantity}
+        disabled={updateLoading}
+        aria-label="Augmenter la quantité"
+        className="flex items-center justify-center w-11.5 h-11.5 ease-out duration-200 hover:text-blue disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <svg className="fill-current" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M3.33301 10C3.33301 9.5398 3.7061 9.16671 4.16634 9.16671H15.833C16.2932 9.16671 16.6663 9.5398 16.6663 10C16.6663 10.4603 16.2932 10.8334 15.833 10.8334H4.16634C3.7061 10.8334 3.33301 10.4603 3.33301 10Z" fill="" />
+          <path d="M9.99967 16.6667C9.53944 16.6667 9.16634 16.2936 9.16634 15.8334L9.16634 4.16671C9.16634 3.70647 9.53944 3.33337 9.99967 3.33337C10.4599 3.33337 10.833 3.70647 10.833 4.16671L10.833 15.8334C10.833 16.2936 10.4599 16.6667 9.99967 16.6667Z" fill="" />
+        </svg>
+      </button>
+    </div>
+  );
+
+  const supprimerBouton = (
+    <button
+      onClick={handleRemoveFromCart}
+      disabled={deleteLoading}
+      aria-label="Retirer du panier"
+      className="flex flex-shrink-0 items-center justify-center rounded-lg w-9.5 h-9.5 bg-gray-2 border border-gray-3 text-dark ease-out duration-200 hover:bg-red-light-6 hover:border-red-light-4 hover:text-red disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      <svg className="fill-current" width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path fillRule="evenodd" clipRule="evenodd" d="M9.45017 2.06252H12.5498C12.7482 2.06239 12.921 2.06228 13.0842 2.08834C13.7289 2.19129 14.2868 2.59338 14.5883 3.17244C14.6646 3.319 14.7192 3.48298 14.7818 3.6712L14.8841 3.97819C14.9014 4.03015 14.9064 4.04486 14.9105 4.05645C15.0711 4.50022 15.4873 4.80021 15.959 4.81217C15.9714 4.81248 15.9866 4.81254 16.0417 4.81254H18.7917C19.1714 4.81254 19.4792 5.12034 19.4792 5.50004C19.4792 5.87973 19.1714 6.18754 18.7917 6.18754H3.20825C2.82856 6.18754 2.52075 5.87973 2.52075 5.50004C2.52075 5.12034 2.82856 4.81254 3.20825 4.81254H5.95833C6.01337 4.81254 6.02856 4.81248 6.04097 4.81217C6.51273 4.80021 6.92892 4.50024 7.08944 4.05647C7.09366 4.0448 7.09852 4.03041 7.11592 3.97819L7.21823 3.67122C7.28083 3.48301 7.33538 3.319 7.41171 3.17244C7.71324 2.59339 8.27112 2.19129 8.91581 2.08834C9.079 2.06228 9.25181 2.06239 9.45017 2.06252ZM8.25739 4.81254C8.30461 4.71993 8.34645 4.6237 8.38245 4.52419C8.39338 4.49397 8.4041 4.4618 8.41787 4.42048L8.50936 4.14601C8.59293 3.8953 8.61217 3.84416 8.63126 3.8075C8.73177 3.61448 8.91773 3.48045 9.13263 3.44614C9.17345 3.43962 9.22803 3.43754 9.49232 3.43754H12.5077C12.772 3.43754 12.8265 3.43962 12.8674 3.44614C13.0823 3.48045 13.2682 3.61449 13.3687 3.8075C13.3878 3.84416 13.4071 3.89529 13.4906 4.14601L13.5821 4.42031L13.6176 4.52421C13.6535 4.62372 13.6954 4.71994 13.7426 4.81254H8.25739Z" fill="" />
+        <path d="M5.42208 7.74597C5.39683 7.36711 5.06923 7.08047 4.69038 7.10572C4.31152 7.13098 4.02487 7.45858 4.05013 7.83743L4.47496 14.2099C4.55333 15.3857 4.61663 16.3355 4.76511 17.0808C4.91947 17.8557 5.18203 18.5029 5.72432 19.0103C6.26662 19.5176 6.92987 19.7365 7.7133 19.839C8.46682 19.9376 9.41871 19.9376 10.5971 19.9375H11.4028C12.5812 19.9376 13.5332 19.9376 14.2867 19.839C15.0701 19.7365 15.7334 19.5176 16.2757 19.0103C16.818 18.5029 17.0805 17.8557 17.2349 17.0808C17.3834 16.3355 17.4467 15.3857 17.525 14.2099L17.9499 7.83743C17.9751 7.45858 17.6885 7.13098 17.3096 7.10572C16.9308 7.08047 16.6032 7.36711 16.5779 7.74597L16.1563 14.0702C16.0739 15.3057 16.0152 16.1654 15.8864 16.8122C15.7614 17.4396 15.5869 17.7717 15.3363 18.0062C15.0857 18.2406 14.7427 18.3926 14.1084 18.4756C13.4544 18.5612 12.5927 18.5625 11.3545 18.5625H10.6455C9.40727 18.5625 8.54559 18.5612 7.89164 18.4756C7.25731 18.3926 6.91433 18.2406 6.6637 18.0062C6.41307 17.7717 6.2386 17.4396 6.11361 16.8122C5.98476 16.1654 5.92607 15.3057 5.8437 14.0702L5.42208 7.74597Z" fill="" />
+        <path d="M8.63993 9.39928C9.01774 9.3615 9.35464 9.63715 9.39242 10.015L9.85076 14.5983C9.88854 14.9761 9.61289 15.313 9.23508 15.3508C8.85727 15.3886 8.52036 15.1129 8.48258 14.7351L8.02425 10.1518C7.98647 9.77397 8.26212 9.43706 8.63993 9.39928Z" fill="" />
+        <path d="M13.3601 9.39928C13.7379 9.43706 14.0135 9.77397 13.9758 10.1518L13.5174 14.7351C13.4796 15.1129 13.1427 15.3886 12.7649 15.3508C12.3871 15.313 12.1115 14.9761 12.1492 14.5983L12.6076 10.015C12.6454 9.63715 12.9823 9.3615 13.3601 9.39928Z" fill="" />
+      </svg>
+    </button>
+  );
+
+  return (
+    <>
+      {/* Carte : mobile et tablette (le tableau imposait un scroll horizontal) */}
+      <div className="xl:hidden flex gap-4 border-t border-gray-3 p-4 sm:p-6">
+        <div className="flex-shrink-0 w-20 h-20 rounded-[5px] bg-gray-2 overflow-hidden">{image}</div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-3">
+            <h3 className="font-medium break-words">{nom}</h3>
+            {supprimerBouton}
+          </div>
+          <p className="text-custom-sm text-dark-4 mt-1">{formatPrice(unitPrice)} l&apos;unité</p>
+          <div className="flex flex-wrap items-center justify-between gap-3 mt-3">
+            {quantite}
+            <p className="text-dark font-medium">{formatPrice(subtotal)}</p>
           </div>
         </div>
       </div>
 
-      <div className="min-w-[180px]">
-        <p className="text-dark">{formatPrice(unitPrice)}</p>
-      </div>
-
-      <div className="min-w-[275px]">
-        <div className="w-max flex items-center rounded-md border border-gray-3">
-          <button
-            onClick={handleDecreaseQuantity}
-            disabled={updateLoading || item.quantite <= 1}
-            aria-label="button for remove product"
-            className="flex items-center justify-center w-11.5 h-11.5 ease-out duration-200 hover:text-blue disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <svg
-              className="fill-current"
-              width="20"
-              height="20"
-              viewBox="0 0 20 20"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M3.33301 10.0001C3.33301 9.53984 3.7061 9.16675 4.16634 9.16675H15.833C16.2932 9.16675 16.6663 9.53984 16.6663 10.0001C16.6663 10.4603 16.2932 10.8334 15.833 10.8334H4.16634C3.7061 10.8334 3.33301 10.4603 3.33301 10.0001Z"
-                fill=""
-              />
-            </svg>
-          </button>
-
-          <span className="flex items-center justify-center w-16 h-11.5 border-x border-gray-4">
-            {updateLoading ? "..." : item.quantite}
-          </span>
-
-          <button
-            onClick={handleIncreaseQuantity}
-            disabled={updateLoading}
-            aria-label="button for add product"
-            className="flex items-center justify-center w-11.5 h-11.5 ease-out duration-200 hover:text-blue disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <svg
-              className="fill-current"
-              width="20"
-              height="20"
-              viewBox="0 0 20 20"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M3.33301 10C3.33301 9.5398 3.7061 9.16671 4.16634 9.16671H15.833C16.2932 9.16671 16.6663 9.5398 16.6663 10C16.6663 10.4603 16.2932 10.8334 15.833 10.8334H4.16634C3.7061 10.8334 3.33301 10.4603 3.33301 10Z"
-                fill=""
-              />
-              <path
-                d="M9.99967 16.6667C9.53944 16.6667 9.16634 16.2936 9.16634 15.8334L9.16634 4.16671C9.16634 3.70647 9.53944 3.33337 9.99967 3.33337C10.4599 3.33337 10.833 3.70647 10.833 4.16671L10.833 15.8334C10.833 16.2936 10.4599 16.6667 9.99967 16.6667Z"
-                fill=""
-              />
-            </svg>
-          </button>
+      {/* Ligne de tableau : desktop */}
+      <div className="hidden xl:flex items-center border-t border-gray-3 py-5 px-7.5">
+        <div className="min-w-[400px]">
+          <div className="w-full flex items-center gap-5.5">
+            <div className="flex items-center justify-center rounded-[5px] bg-gray-2 max-w-[80px] w-full h-17.5 overflow-hidden">
+              {image}
+            </div>
+            <h3>{nom}</h3>
+          </div>
         </div>
-      </div>
 
-      <div className="min-w-[200px]">
-        <p className="text-dark font-medium">{formatPrice(subtotal)}</p>
-      </div>
+        <div className="min-w-[180px]">
+          <p className="text-dark">{formatPrice(unitPrice)}</p>
+        </div>
 
-      <div className="min-w-[50px] flex justify-end">
-        <button
-          onClick={handleRemoveFromCart}
-          disabled={deleteLoading}
-          aria-label="button for remove product from cart"
-          className="flex items-center justify-center rounded-lg max-w-[38px] w-full h-9.5 bg-gray-2 border border-gray-3 text-dark ease-out duration-200 hover:bg-red-light-6 hover:border-red-light-4 hover:text-red disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          <svg
-            className="fill-current"
-            width="22"
-            height="22"
-            viewBox="0 0 22 22"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M9.45017 2.06252H12.5498C12.7482 2.06239 12.921 2.06228 13.0842 2.08834C13.7289 2.19129 14.2868 2.59338 14.5883 3.17244C14.6646 3.319 14.7192 3.48298 14.7818 3.6712L14.8841 3.97819C14.9014 4.03015 14.9064 4.04486 14.9105 4.05645C15.0711 4.50022 15.4873 4.80021 15.959 4.81217C15.9714 4.81248 15.9866 4.81254 16.0417 4.81254H18.7917C19.1714 4.81254 19.4792 5.12034 19.4792 5.50004C19.4792 5.87973 19.1714 6.18754 18.7917 6.18754H3.20825C2.82856 6.18754 2.52075 5.87973 2.52075 5.50004C2.52075 5.12034 2.82856 4.81254 3.20825 4.81254H5.95833C6.01337 4.81254 6.02856 4.81248 6.04097 4.81217C6.51273 4.80021 6.92892 4.50024 7.08944 4.05647C7.09366 4.0448 7.09852 4.03041 7.11592 3.97819L7.21823 3.67122C7.28083 3.48301 7.33538 3.319 7.41171 3.17244C7.71324 2.59339 8.27112 2.19129 8.91581 2.08834C9.079 2.06228 9.25181 2.06239 9.45017 2.06252ZM8.25739 4.81254C8.30461 4.71993 8.34645 4.6237 8.38245 4.52419C8.39338 4.49397 8.4041 4.4618 8.41787 4.42048L8.50936 4.14601C8.59293 3.8953 8.61217 3.84416 8.63126 3.8075C8.73177 3.61448 8.91773 3.48045 9.13263 3.44614C9.17345 3.43962 9.22803 3.43754 9.49232 3.43754H12.5077C12.772 3.43754 12.8265 3.43962 12.8674 3.44614C13.0823 3.48045 13.2682 3.61449 13.3687 3.8075C13.3878 3.84416 13.4071 3.89529 13.4906 4.14601L13.5821 4.42031L13.6176 4.52421C13.6535 4.62372 13.6954 4.71994 13.7426 4.81254H8.25739Z"
-              fill=""
-            />
-            <path
-              d="M5.42208 7.74597C5.39683 7.36711 5.06923 7.08047 4.69038 7.10572C4.31152 7.13098 4.02487 7.45858 4.05013 7.83743L4.47496 14.2099C4.55333 15.3857 4.61663 16.3355 4.76511 17.0808C4.91947 17.8557 5.18203 18.5029 5.72432 19.0103C6.26662 19.5176 6.92987 19.7365 7.7133 19.839C8.46682 19.9376 9.41871 19.9376 10.5971 19.9375H11.4028C12.5812 19.9376 13.5332 19.9376 14.2867 19.839C15.0701 19.7365 15.7334 19.5176 16.2757 19.0103C16.818 18.5029 17.0805 17.8557 17.2349 17.0808C17.3834 16.3355 17.4467 15.3857 17.525 14.2099L17.9499 7.83743C17.9751 7.45858 17.6885 7.13098 17.3096 7.10572C16.9308 7.08047 16.6032 7.36711 16.5779 7.74597L16.1563 14.0702C16.0739 15.3057 16.0152 16.1654 15.8864 16.8122C15.7614 17.4396 15.5869 17.7717 15.3363 18.0062C15.0857 18.2406 14.7427 18.3926 14.1084 18.4756C13.4544 18.5612 12.5927 18.5625 11.3545 18.5625H10.6455C9.40727 18.5625 8.54559 18.5612 7.89164 18.4756C7.25731 18.3926 6.91433 18.2406 6.6637 18.0062C6.41307 17.7717 6.2386 17.4396 6.11361 16.8122C5.98476 16.1654 5.92607 15.3057 5.8437 14.0702L5.42208 7.74597Z"
-              fill=""
-            />
-            <path
-              d="M8.63993 9.39928C9.01774 9.3615 9.35464 9.63715 9.39242 10.015L9.85076 14.5983C9.88854 14.9761 9.61289 15.313 9.23508 15.3508C8.85727 15.3886 8.52036 15.1129 8.48258 14.7351L8.02425 10.1518C7.98647 9.77397 8.26212 9.43706 8.63993 9.39928Z"
-              fill=""
-            />
-            <path
-              d="M13.3601 9.39928C13.7379 9.43706 14.0135 9.77397 13.9758 10.1518L13.5174 14.7351C13.4796 15.1129 13.1427 15.3886 12.7649 15.3508C12.3871 15.313 12.1115 14.9761 12.1492 14.5983L12.6076 10.015C12.6454 9.63715 12.9823 9.3615 13.3601 9.39928Z"
-              fill=""
-            />
-          </svg>
-        </button>
+        <div className="min-w-[275px]">{quantite}</div>
+
+        <div className="min-w-[200px]">
+          <p className="text-dark font-medium">{formatPrice(subtotal)}</p>
+        </div>
+
+        <div className="min-w-[50px] flex justify-end">{supprimerBouton}</div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/T-Express-Frontend/src/components/Cart/index.tsx
+++ b/T-Express-Frontend/src/components/Cart/index.tsx
@@ -34,9 +34,9 @@ const Cart = () => {
         <section className="overflow-hidden py-20 bg-gray-2">
           <div className="max-w-[1170px] w-full mx-auto px-4 sm:px-8 xl:px-0">
             <div className="animate-pulse">
-              <div className="h-8 bg-gray-300 rounded w-1/4 mb-7.5"></div>
+              <div className="h-8 bg-gray-3 rounded w-1/4 mb-7.5"></div>
               <div className="bg-white rounded-[10px] shadow-1 p-7.5">
-                <div className="h-64 bg-gray-200 rounded"></div>
+                <div className="h-64 bg-gray-2 rounded"></div>
               </div>
             </div>
           </div>
@@ -55,24 +55,26 @@ const Cart = () => {
             </div>
 
             <div className="bg-white rounded-[10px] shadow-1">
-              <div className="w-full overflow-x-auto">
-                <div className="min-w-[1170px]">
+              {/* Tableau à partir de xl seulement : en dessous, chaque ligne
+                  s'affiche en carte (SingleItemNew), sans scroll horizontal. */}
+              <div className="w-full xl:overflow-x-auto">
+                <div className="xl:min-w-[1170px]">
                   {/* <!-- table header --> */}
-                  <div className="flex items-center py-5.5 px-7.5">
+                  <div className="hidden xl:flex items-center py-5.5 px-7.5">
                     <div className="min-w-[400px]">
-                      <p className="text-dark">Product</p>
+                      <p className="text-dark">Produit</p>
                     </div>
 
                     <div className="min-w-[180px]">
-                      <p className="text-dark">Price</p>
+                      <p className="text-dark">Prix</p>
                     </div>
 
                     <div className="min-w-[275px]">
-                      <p className="text-dark">Quantity</p>
+                      <p className="text-dark">Quantité</p>
                     </div>
 
                     <div className="min-w-[200px]">
-                      <p className="text-dark">Subtotal</p>
+                      <p className="text-dark">Sous-total</p>
                     </div>
 
                     <div className="min-w-[50px]">
@@ -82,8 +84,8 @@ const Cart = () => {
 
                   {/* <!-- cart item --> */}
                   {cartItems.length > 0 &&
-                    cartItems.map((item, key) => (
-                      <SingleItemNew item={item} key={key} />
+                    cartItems.map((item) => (
+                      <SingleItemNew item={item} key={item.id} />
                     ))}
                 </div>
               </div>


### PR DESCRIPTION
Closes #30

## Problème
Sur mobile, le panier (`min-w-[1170px]`) et les tableaux admin imposaient un scroll horizontal : seule la première colonne était visible, avec prix, quantité, statuts et actions hors écran. Mesuré à 390 px : commandes 613 px, produits 881 px, livraisons 699 px, catégories 725 px dans un conteneur de 340 px.

## Ce qui change
**Panier**
- Sous `xl`, chaque ligne s'affiche en **carte** : image, nom, prix unitaire, quantité, sous-total, suppression. Au-delà, la ligne de tableau reste identique (le tableau fait 1170 px, d'où `xl` plutôt que `md`). En-têtes traduits (« Produit, Prix, Quantité, Sous-total »), `aria-label` en français.
- 🐛 **Bug corrigé** : chaque ligne (`SingleItemNew`) créait sa propre instance de `usePanier()`, alors que la page lit le contexte partagé. Les boutons +/− modifiaient le backend **sans rafraîchir la quantité affichée, le sous-total, le total ni le compteur du header** (vérifié : API à 2, écran à 1). En plus, chaque ligne rechargeait tout le panier : **16 appels `panier/contenu` au chargement, 6 maintenant**. Les lignes utilisent désormais `usePanierContext()`.

**Admin : commandes, produits, livraisons, catégories**
- Sous `md`, liste en **cartes** avec toutes les informations et actions ; tableau inchangé au-delà.
- Les cellules (select du statut de paiement, badges, boutons d'action) sont factorisées dans des fonctions de rendu partagées par les deux vues : pas de duplication de logique.
- Stocks tenait déjà dans la largeur mobile (et a été retravaillé dans #34).
- Commandes : les badges de statut utilisaient `bg-yellow-100`, `bg-purple-100`…, absents du thème Tailwind (palette redéfinie), et s'affichaient **sans couleur**. Ils sont remappés sur la palette du thème, comme le fond de la modale de détail.

À noter pour plus tard : l'admin contient encore beaucoup d'autres classes hors thème (`bg-gray-50`, `text-gray-500`…), qui méritent un nettoyage global à part.

## Tests (Edge + backend local)
- [x] panier à 390, 820 et 1366 px : aucun débordement ; cartes sous `xl`, tableau à 1366 px
- [x] panier : « + » passe la quantité de 2 à 3 et le sous-total de 50 000 à 75 000 F CFA **à l'écran**
- [x] admin à 390 px : 2, 4, 2 et 1 cartes, tableaux masqués, aucun débordement
- [x] admin à 1366 px : tableaux visibles et inchangés, cartes masquées
- [x] `tsc --noEmit` et ESLint sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
