### PR TITLE
fix: reactive les verifications ESLint et TypeScript au build (#38)

### DIFF
--- a/T-Express-Frontend/next.config.js
+++ b/T-Express-Frontend/next.config.js
@@ -11,15 +11,10 @@ try {
 
 const backendUrl = new URL(backendOrigin);
 
+// Pas de `eslint.ignoreDuringBuilds` ni de `typescript.ignoreBuildErrors` :
+// une erreur ESLint ou TypeScript doit faire échouer `next build` plutôt que
+// de partir en production (les warnings, eux, ne bloquent pas).
 const nextConfig = {
-  // Disable ESLint during production builds
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  // Disable TypeScript errors during builds
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     remotePatterns: [
       {

--- a/T-Express-Frontend/src/app/(site)/(pages)/my-account/orders/page.tsx
+++ b/T-Express-Frontend/src/app/(site)/(pages)/my-account/orders/page.tsx
@@ -123,7 +123,7 @@ export default function OrdersPage() {
                 <svg className="w-16 h-16 mx-auto text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
                 </svg>
-                <p className="text-gray-500 mb-4">Vous n'avez pas encore de commandes</p>
+                <p className="text-gray-500 mb-4">Vous n&apos;avez pas encore de commandes</p>
                 <Link 
                   href="/shop-with-sidebar" 
                   className="inline-flex text-white bg-blue py-2 px-6 rounded-md hover:bg-blue-dark"

--- a/T-Express-Frontend/src/app/orders/[id]/page.tsx
+++ b/T-Express-Frontend/src/app/orders/[id]/page.tsx
@@ -261,7 +261,7 @@ export default function OrderDetailPage() {
 
                 {/* Contact support */}
                 <div className="mt-6 pt-6 border-t">
-                  <h4 className="font-medium text-dark mb-2">Besoin d'aide ?</h4>
+                  <h4 className="font-medium text-dark mb-2">Besoin d&apos;aide ?</h4>
                   <p className="text-sm text-gray-600 mb-3">
                     Contactez notre service client pour toute question concernant votre commande.
                   </p>

--- a/T-Express-Frontend/src/components/Error/index.tsx
+++ b/T-Express-Frontend/src/components/Error/index.tsx
@@ -25,7 +25,7 @@ const Error = () => {
 
               <p className="max-w-[410px] w-full mx-auto mb-7.5">
                 La page que vous recherchez semble avoir été déplacée,
-                supprimée ou n'existe pas.
+                supprimée ou n&apos;existe pas.
               </p>
 
               <Link
@@ -45,7 +45,7 @@ const Error = () => {
                     fill=""
                   />
                 </svg>
-                Retour à l'accueil
+                Retour à l&apos;accueil
               </Link>
             </div>
           </div>

--- a/T-Express-Frontend/src/components/MailSuccess/index.tsx
+++ b/T-Express-Frontend/src/components/MailSuccess/index.tsx
@@ -41,7 +41,7 @@ const MailSuccess = () => {
                     fill=""
                   />
                 </svg>
-                Retour à l'accueil
+                Retour à l&apos;accueil
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Closes #38

## Problème
`next.config.js` désactivait les deux vérifications (`eslint.ignoreDuringBuilds: true`, `typescript.ignoreBuildErrors: true`). Un build de production pouvait donc réussir avec de vraies erreurs et partir en prod sans avertissement.

## Ce qui change
- **Backlog résorbé** : `tsc --noEmit` ne remonte aucune erreur. Les **5 erreurs ESLint** restantes (apostrophes non échappées dans du JSX, `react/no-unescaped-entities`) sont corrigées dans `my-account/orders`, `orders/[id]`, `Error` et `MailSuccess`.
- **Les deux options sont retirées** de `next.config.js`.

## Vérifications
- [x] `next build` : réussit, et l'étape **« Linting and checking validity of types »** s'exécute (elle était sautée avant)
- [x] **contre-épreuve** : avec une erreur de type volontaire, `next build` échoue (`Type error: Type 'string' is not assignable to type 'number'`, exit 1). Erreur retirée avant le commit
- [x] `next lint` : 0 erreur. Il reste une poignée de **warnings** préexistants (`react-hooks/exhaustive-deps`, `@next/next/no-img-element`…), qui ne bloquent pas le build

## ⚠️ Déploiement
Le prochain `docker compose up -d --build` du frontend exécutera ces vérifications. Le code actuel de `main` les passe. Une future erreur ESLint ou TypeScript fera désormais échouer le build **au lieu de partir en production**, ce qui est l'objectif du ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
